### PR TITLE
feat: Add GitHub Actions for BTF generation (take 2)

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,38 @@
+name: Update BTFHub Archives
+on:
+  schedule:
+  - cron: '0 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Update BTF
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Check out code repo
+      uses: actions/checkout@v2
+
+    - name: Checkout public BTFHub repo
+      uses: actions/checkout@v2
+      with:
+        repository: aquasecurity/btfhub-archive
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
+        path: btfhub-archive-repo
+
+    - name: Prepare current BTFHub repo archives
+      run: make gather
+
+    - name: Install packages required for BTF downloads
+      run: sudo apt-get install -y lynx
+
+    - name: Update BTF archives
+      run: make update
+
+    - name: Commit and Push to BTFHub repo
+      run: |
+        cd btfhub-archive-repo
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add -A
+        git diff-index --quiet HEAD || git commit -m "Update BTF Archives"
+        git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea*
+btfhub-archive-repo
+archive

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+gather:
+	rm -rf archive
+	mkdir archive
+	rsync -av ./btfhub-archive-repo/ archive/ --exclude=.git
+
+update:
+	for distro in fedora29 fedora30 fedora31 fedora32 fedora33 fedora34 centos7 centos8 bionic focal; do \
+  		./tools/update.sh $$distro; \
+	done
+	rsync -av ./archive/ btfhub-archive-repo --exclude=.gitignore


### PR DESCRIPTION
New PR to make it mergeable with new revision history of the repo

This PR will add automatic generation of BTF archives within a GitHub Action.

The push will be done to the btfhub-archive repo if changes are found, automatically.

Sample run: https://github.com/simar7/btfhub/runs/4293008009?check_suite_focus=true