### PR TITLE
feat: Add bats test for update.sh

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,38 @@
+name: Update BTFHub Archives
+on:
+  schedule:
+  - cron: '0 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Update BTF
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Check out code repo
+      uses: actions/checkout@v2
+
+    - name: Checkout public BTFHub repo
+      uses: actions/checkout@v2
+      with:
+        repository: aquasecurity/btfhub-archive
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
+        path: btfhub-archive-repo
+
+    - name: Prepare current BTFHub repo archives
+      run: make gather
+
+    - name: Install packages required for BTF downloads
+      run: sudo apt-get install -y lynx
+
+    - name: Update BTF archives
+      run: make update
+
+    - name: Commit and Push to BTFHub repo
+      run: |
+        cd btfhub-archive-repo
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add -A
+        git diff-index --quiet HEAD || git commit -m "Update BTF Archives"
+        git push

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -23,7 +23,10 @@ jobs:
       run: make gather
 
     - name: Install packages required for BTF downloads
-      run: sudo apt-get install -y lynx
+      run: |
+        sudo add-apt-repository -y ppa:rafaeldtinoco/dwarves
+        sudo apt-get update
+        sudo apt-get install -y dwarves lynx
 
     - name: Update BTF archives
       run: make update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Run Tests
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: BATS Tests
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Check out code repo
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Checkout public BTFHub repo
+      uses: actions/checkout@v2
+      with:
+        repository: aquasecurity/btfhub-archive
+        path: btfhub-archive-repo
+
+    - name: Prepare current BTFHub repo archives
+      run: make gather
+
+    - name: Install packages required for BTF downloads
+      run: |
+        sudo add-apt-repository -y ppa:rafaeldtinoco/dwarves
+        sudo apt-get update
+        sudo apt-get install -y dwarves lynx
+        sudo npm install -g bats
+
+    - name: Run tests
+      run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea*
+btfhub-archive-repo
+archive

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea*
 btfhub-archive-repo
 archive
+test/test_helper

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "test/test_helper/bats-support"]
+	path = test/test_helper/bats-support
+	url = https://github.com/bats-core/bats-support.git
+[submodule "test/test_helper/bats-assert"]
+	path = test/test_helper/bats-assert
+	url = https://github.com/bats-core/bats-assert.git

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: gather update test
+
 gather:
 	rm -rf archive
 	mkdir archive
@@ -8,3 +10,6 @@ update:
   		./tools/update.sh $$distro; \
 	done
 	rsync -av ./archive/ btfhub-archive-repo --exclude=.gitignore
+
+test:
+	bats test/test.bats

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+gather:
+	rm -rf archive
+	mkdir archive
+	rsync -av ./btfhub-archive-repo/ archive/ --exclude=.git
+
+update:
+	for distro in fedora29 fedora30 fedora31 fedora32 fedora33 fedora34 centos7 centos8 bionic focal; do \
+  		./tools/update.sh $$distro; \
+	done
+	rsync -av ./archive/ btfhub-archive-repo --exclude=.gitignore

--- a/test/test.bats
+++ b/test/test.bats
@@ -1,0 +1,68 @@
+setup() {
+    load 'test_helper/bats-support/load'
+    load 'test_helper/bats-assert/load'
+
+    DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )"
+    PATH="$DIR/../tools:$PATH"
+}
+
+
+@test "run update.sh with ubuntu/bionic and ensure no errors" {
+    run update.sh bionic
+    assert_success
+    refute_output --partial 'ERROR'
+}
+
+@test "run update.sh with ubuntu/focal and ensure no errors" {
+    run update.sh focal
+    assert_success
+    refute_output --partial 'ERROR'
+}
+
+@test "run update.sh with fedora/29 and ensure no errors" {
+    run update.sh fedora29
+    assert_success
+    refute_output --partial 'ERROR'
+}
+
+@test "run update.sh with fedora/30 and ensure no errors" {
+    run update.sh fedora30
+    assert_success
+    refute_output --partial 'ERROR'
+}
+
+@test "run update.sh with fedora/31 and ensure no errors" {
+    run update.sh fedora31
+    assert_success
+    refute_output --partial 'ERROR'
+}
+
+@test "run update.sh with fedora/32 and ensure no errors" {
+    run update.sh fedora32
+    assert_success
+    refute_output --partial 'ERROR'
+}
+
+@test "run update.sh with fedora/33 and ensure no errors" {
+    run update.sh fedora33
+    assert_success
+    refute_output --partial 'ERROR'
+}
+
+@test "run update.sh with fedora/34 and ensure no errors" {
+    run update.sh fedora34
+    assert_success
+    refute_output --partial 'ERROR'
+}
+
+@test "run update.sh with centos/7 and ensure no errors" {
+    run update.sh centos7
+    assert_success
+    refute_output --partial 'ERROR'
+}
+
+@test "run update.sh with centos/8 and ensure no errors" {
+    run update.sh centos8
+    assert_success
+    refute_output --partial 'ERROR'
+}

--- a/tools/update.sh
+++ b/tools/update.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo "Updating BTF archives..."
+
 ##
 ## This script IS SUPPOSED to be a big monolithic script.
 ## That's it: The tree should focus in arranging BTF data.


### PR DESCRIPTION
**Summary:**
This PR adds tests for `update.sh` by asserting on the behaviour that BTF archives can be properly pulled and generated. 

**How to run:**
`make test`

You can see a sample run here: https://github.com/aquasecurity/btfhub/runs/4337240286?check_suite_focus=true
<img width="972" alt="image" src="https://user-images.githubusercontent.com/1254783/143624347-63030f9d-64ec-4ec1-b0c4-bab869c1d7ae.png">


The tests will also be run on each PR as it is created.
Read more on BATS: https://bats-core.readthedocs.io/en/stable/