### PR TITLE
Add missing ubuntu 18.04 versions

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -1,0 +1,34 @@
+name: Diff with BTFHub Archives
+on:
+  pull_request:
+
+jobs:
+  diff:
+    name: Diff with BTFHub archive
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Check out code repo
+      uses: actions/checkout@v2
+
+    - name: Checkout public BTFHub repo
+      uses: actions/checkout@v2
+      with:
+        repository: aquasecurity/btfhub-archive
+        path: btfhub-archive-repo
+
+    - name: Prepare current BTFHub repo archives
+      run: make gather
+
+    - name: Install packages required for BTF downloads
+      run: |
+        sudo add-apt-repository -y ppa:rafaeldtinoco/dwarves
+        sudo apt-get update
+        sudo apt-get install -y dwarves lynx sqlite3
+
+    - name: Update BTF archives
+      run: make update
+
+    - name: Diff with BTFHub Archive
+      run: |
+        cd btfhub-archive-repo
+        git status

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ update:
 	do \
 		./tools/update.sh $$distro; \
 	done
+	./tools/update.sh bionic 4.15.0
 	rsync -av ./archive/ btfhub-archive-repo --exclude=.gitignore
 
 test:

--- a/tools/update.sh
+++ b/tools/update.sh
@@ -40,16 +40,34 @@ for arch in x86_64 arm64; do
 
 for ubuntuver in bionic focal; do
 
-    if [ "${1}" != "${ubuntuver}" ]; then
+if [ "${1}" != "${ubuntuver}" ]; then
+    continue
+fi
+
+case "${ubuntuver}" in
+"bionic")
+    kernelversions=("4.15.0" "5.4.0")
+    ;;
+"focal")
+    kernelversions=("5.4.0" "5.8.0" "5.11.0")
+    ;;
+*)
+    continue
+    ;;
+esac
+
+for kernelver in $kernelversions; do
+
+    if [ -z "${2}" ] || [ "${2}" != "${kernelver}" ]; then
         continue
     fi
 
     case "${ubuntuver}" in
     "bionic")
-        regex="(linux-image-unsigned-(4.15.0|5.4.0)-.*-(generic|azure|gke|gcp)-dbgsym|linux-image-(4.15.0|5.4.0)-.*-aws-dbgsym)"
+        regex="(linux-image-unsigned-$kernelver-.*-(generic|azure|gke|gcp)-dbgsym|linux-image-$kernelver-.*-aws-dbgsym)"
         ;;
     "focal")
-        regex="(linux-image-unsigned-(5.4.0|5.8.0|5.11.0)-.*-(generic|azure|gke|gcp)-dbgsym|linux-image-(5.4.0|5.8.0|5.11.0)-.*-aws-dbgsym)"
+        regex="(linux-image-unsigned-$kernelver-.*-(generic|azure|gke|gcp)-dbgsym|linux-image-$kernelver-.*-aws-dbgsym)"
         ;;
     *)
         continue
@@ -71,7 +89,7 @@ for ubuntuver in bionic focal; do
     origdir=$(pwd)
     repository="http://ddebs.ubuntu.com"
 
-    mkdir -p "${basedir}/ubuntu/${ubuntuver}"
+    mkdir -p "${basedir}/ubuntu/${ubuntuver}/${arch}"
     cd "${basedir}/ubuntu/${ubuntuver}/${arch}" || exiterr "no ${ubuntuver} dir found"
 
     wget http://ddebs.ubuntu.com/dists/${ubuntuver}/main/binary-${altarch}/Packages -O ${ubuntuver}
@@ -130,7 +148,7 @@ for ubuntuver in bionic focal; do
 
         }
 
-	    rm -rf "${basedir}/ubuntu/${ubuntuver}/${arch}/usr"
+	    rm -rf "./usr"
 
 	    pahole --btf_encode_detached "${version}.btf" "${version}.vmlinux"
 	    # pahole "./${version}.btf" > "${version}.txt"
@@ -146,6 +164,8 @@ for ubuntuver in bionic focal; do
     pwd
     rm -f packages
     cd "${origdir}" >/dev/null || exit
+
+done # kernelver
 
 done
 
@@ -189,7 +209,7 @@ for centosver in centos7 centos8; do
 
     regex="kernel-debuginfo-[0-9].*${altarch}.rpm"
 
-    mkdir -p "${basedir}/centos/${centosver/centos/}"
+    mkdir -p "${basedir}/centos/${centosver/centos/}/${arch}"
     cd "${basedir}/centos/${centosver/centos/}/${arch}" || exiterr "no ${centosver} dir found"
 
     info "downloading ${repository} information"
@@ -295,7 +315,7 @@ for fedoraver in fedora29 fedora30 fedora31 fedora32 fedora33 fedora34; do
 
     regex="kernel-debuginfo-[0-9].*${altarch}.rpm"
 
-    mkdir -p "${basedir}/fedora/${fedoraver/fedora/}"
+    mkdir -p "${basedir}/fedora/${fedoraver/fedora/}/${arch}"
     cd "${basedir}/fedora/${fedoraver/fedora/}/${arch}" || exiterr "no ${fedoraver} dir found"
 
     info "downloading ${repository01} information"


### PR DESCRIPTION
First of all thank you for this project.

989e0f5d46e56f7028a6455201ec97d69e1d8d3e removed the update of bionic kernels even though some 4.15 kernels are still updated by ubuntu. This means that we are missing some BTF files:
```
ubuntu/18.04/arm64/4.15.0-1121-aws.failed
ubuntu/18.04/arm64/4.15.0-1123-aws.failed
ubuntu/18.04/arm64/4.15.0-1124-aws.failed
ubuntu/18.04/x86_64/4.15.0-1116-gcp.btf.tar.xz
ubuntu/18.04/x86_64/4.15.0-1118-gcp.btf.tar.xz
ubuntu/18.04/x86_64/4.15.0-1119-gcp.btf.tar.xz
ubuntu/18.04/x86_64/4.15.0-1121-aws.failed
ubuntu/18.04/x86_64/4.15.0-1123-aws.failed
ubuntu/18.04/x86_64/4.15.0-1124-aws.failed
ubuntu/18.04/x86_64/4.15.0-1131-azure.btf.tar.xz
ubuntu/18.04/x86_64/4.15.0-1133-azure.btf.tar.xz
ubuntu/18.04/x86_64/4.15.0-1134-azure.btf.tar.xz
ubuntu/18.04/x86_64/4.15.0-169-generic.btf.tar.xz
ubuntu/18.04/x86_64/4.15.0-171-generic.btf.tar.xz
ubuntu/18.04/x86_64/4.15.0-173-generic.btf.tar.xz
```

This PR:
- fixes some issues in the update script around `mkdir` and `rm -rf` cleanup operations
- adds a diff workflow that runs on pull request, runs the update script and display what would be updated by this PR
- adds a way to run the update script as `./tools/update.sh bionic 4.15.0` to specifically update the bionic 4.15 kernels
   - `./tools/update.sh bionic` still works as before

Happy to improve the update script in any way if desired.

Thank you