### PR TITLE
Bump actions/checkout to v3

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out code repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Checkout public BTFHub repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: aquasecurity/btfhub-archive
           token: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out code repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Checkout public BTFHub repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: aquasecurity/btfhub-archive
           path: btfhub-archive-repo


### PR DESCRIPTION
Recent runs of actions display:
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout, actions/checkout, actions/checkout
```
Example: https://github.com/aquasecurity/btfhub/actions/runs/3246830961

This PR fixes the issue by bumping the checkout actions