### PR TITLE
Fix RHEL 7 x86_64 release

### DIFF
--- a/tools/update.sh
+++ b/tools/update.sh
@@ -794,7 +794,8 @@ for rhelver in rhel7 rhel8; do
 
     case "${rhelver}:${arch}" in
         "rhel7:x86_64")
-            releasevers=("7.6" "7.7" "7.8" "7.9")
+            # 7.7 is necessary for access to EUS repos
+            releasevers=("7.7")
         ;;
         "rhel7:arm64")
             releasevers=("7Server")


### PR DESCRIPTION
You can see all kernels with a single release, but you need 7.7 to access the EUS repos.