### PR TITLE
fix: executables not found in $PATH

### DIFF
--- a/.github/actions/build-dependencies/action.yaml
+++ b/.github/actions/build-dependencies/action.yaml
@@ -12,8 +12,10 @@ runs:
   steps:
     - name: Install Base Packages
       run: |
+        echo 'MIRRORSITE=http://archive.ubuntu.com/ubuntu' | sudo tee '/etc/pbuilderrc'
         sudo apt-get update
-        sudo apt-get install -y bsdutils build-essential pkgconf
+        sudo apt-get install -y ubuntu-dev-tools
+        sudo apt-get install -y bsdutils build-essential pkgconf pahole
         sudo apt-get install -y zlib1g-dev libelf-dev
         sudo apt-get install -y software-properties-common
       shell: bash


### PR DESCRIPTION
Hey 👋🏾,

I noticed the action runs have been silently failing when executing `pahole` (Ubuntu and Oracle Linux recently) or `pull-lp-ddebs` (for Ubuntu) due to the runner not having either installed it seems. This relates to issue #84. 

```bash
# pahole not found
2023/04/22 01:56:55 ERROR: btf gen: pahole --btf_encode_detached /home/runner/work/btfhub/btfhub/btfhub/archive/ubuntu/bionic/x86_64/4.15.0-1163-azure.btf /home/runner/work/btfhub/btfhub/btfhub/archive/ubuntu/bionic/x86_64/vmlinux-4.15.0-1163-azure: exec: "pahole": executable file not found in $PATH

2023/04/22 02:10:59 ERROR: btf gen: pahole --btf_encode_detached /home/runner/work/btfhub/btfhub/btfhub/archive/ol/7/x86_64/4.14.35-2047.524.5.el7uek.x86_64.btf /home/runner/work/btfhub/btfhub/btfhub/archive/ol/7/x86_64/vmlinux-4.14.35-2047.524.5.el7uek.x86_64: exec: "pahole": executable file not found in $PATH

# pull-lp-ddebs not found
2023/04/19 01:39:37 ERROR: linux-image-unsigned-4.15.0-209-generic-dbgsym amd64: downloading ddeb package: pull-lp-ddebs: exec: "pull-lp-ddebs": executable file not found in $PATH
```

This set of package installs worked for me when using a local and GitHub-hosted runner. 