### PR TITLE
build pahole from source

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -24,7 +24,24 @@ jobs:
       - name: Install Dependencies
         run: |
           apt-get update -y
-          apt-get install -y pahole ubuntu-dev-tools
+          apt-get install -y ubuntu-dev-tools cmake libdw-dev
+      #
+      - name: Check out dwarves
+        uses: actions/checkout@v3
+        with:
+          repository: acmel/dwarves
+          ref: 0a1944b
+          path: ./dwarves
+          token: ${{ secrets.PAT_RAFAEL }}
+      #
+      - name: Compile pahole
+        run: |
+          pushd dwarves
+          mkdir build
+          cd build
+          cmake -D__LIB=lib ..
+          make install
+          popd
       #
       - name: Check out BTFHub
         uses: actions/checkout@v3


### PR DESCRIPTION
To avoid [a bug](https://bugs.launchpad.net/ubuntu/+source/dwarves/+bug/2025370) with Ubuntu's `pahole`, and to allow us to use newer flags.