### PR TITLE
respect system's bpftool path

### DIFF
--- a/tools/btfgen.sh
+++ b/tools/btfgen.sh
@@ -42,7 +42,11 @@ fi
 
 cd ${basedir}
 
-btfgen=/usr/sbin/bpftool
+btfgen=$(which bpftool)
+if [ -z "${btfgen}" ]; then
+    btfgen=/usr/sbin/bpftool
+fi
+
 if [ ! -x "${btfgen}" ]; then
     echo "error: could not find bpftool (w/ btfgen patch) tool"
     exit 1


### PR DESCRIPTION
Some systems ship with very old versions of `bpftool` and updating using `apt`; although successful, never really brings the up-to-date version.

One way to tackle this is to build from source. Hard-coding the path of the bpftool on those systems results in the use of the older binary.

This change, will give the system a chance to use the intended bpftool.