### PR TITLE
Add "k/" to URL for Fedora updates

### DIFF
--- a/pkg/repo/fedora.go
+++ b/pkg/repo/fedora.go
@@ -32,7 +32,7 @@ var oldRepoOrganization = []string{
 
 var repoOrganization = []string{
 	"https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/%s/Everything/%s/debug/tree/Packages/k/",
-	"https://archives.fedoraproject.org/pub/archive/fedora/linux/updates/%s/Everything/%s/debug/Packages/",
+	"https://archives.fedoraproject.org/pub/archive/fedora/linux/updates/%s/Everything/%s/debug/Packages/k/",
 }
 
 func NewFedoraRepo() Repository {


### PR DESCRIPTION
IIUC, this was accidentally lost in
https://github.com/aquasecurity/btfhub/commit/c22ad47e3432e22ed4052b220b12651ab0137433, and caused the BTF for 5.8.18-100.fc31.x86_64.btf to be removed from the archive.