### PR TITLE
chore: multiple patterns for sparse-checkout

### DIFF
--- a/tools/archive-sparse-checkout.sh
+++ b/tools/archive-sparse-checkout.sh
@@ -1,32 +1,39 @@
-#!/bin/sh
+#!/bin/bash
 
 die() {
     echo "${@}"
     exit 1
 }
 
-if [ -z "$ARCH" ]; then
-  ARCH="*"
-else
-    case ${ARCH} in
-    "x86_64")
-        ARCH="x86_64"
-        ;;
-    "aarch64"|"arm64")
-        ARCH="arm64"
-        ;;
-    *)
-        die "unsupported architecture: ${ARCH}"
-        ;;
-    esac
-fi
-
-if [ -z "$DISTRO" ]; then
-  DISTRO="*"
-fi
-
 if [ -z "$VERSION" ]; then
-  VERSION="*"
+    VERSION="*"
+fi
+
+set -f # disable globbing
+DISTROS=${DISTRO:-"*"}
+ARCHS=${ARCH:-"*"}
+
+ARCHS="${ARCHS//aarch64/arm64}"
+for arch in $ARCHS; do
+    case $arch in
+        x86_64|arm64|'*')
+            ;;
+        *)
+            die "invalid ARCH: $arch"
+            ;;
+    esac
+done
+set +f # enable globbing
+
+IFS=' ' read -r -a DISTROS_ARRAY <<< "$DISTROS"
+IFS=' ' read -r -a ARCHS_ARRAY <<< "$ARCHS"
+
+# count the number of elements
+NUM_DISTROS=${#DISTROS_ARRAY[@]}
+NUM_ARCHS=${#ARCHS_ARRAY[@]}
+
+if [ "$VERSION" != "*" ] && { [ "$NUM_DISTROS" -gt 1 ] || [ "$NUM_ARCHS" -gt 1 ]; }; then
+    die "VERSION must be * when DISTRO or ARCH are arrays"
 fi
 
 BASE_DIR=$(dirname "$(realpath "$0")")
@@ -46,11 +53,31 @@ else
     git clone --sparse --filter=blob:none "$REPO_URL" "$ARCHIVE_DIR"
 fi
 
+SPARSE_CHECKOUT_FILE="$ARCHIVE_DIR/.git/info/sparse-checkout"
+true > "$SPARSE_CHECKOUT_FILE" # clear existing file
+
 # initialize sparse-checkout
 git -C "$ARCHIVE_DIR" sparse-checkout init --no-cone
 
-# write patterns for the files we want to pull
-echo "$DISTRO/$VERSION/$ARCH/*.btf.tar.xz" > "$ARCHIVE_DIR/.git/info/sparse-checkout"
+echo "Settings patterns to $SPARSE_CHECKOUT_FILE file..."
+if [ "$NUM_DISTROS" -eq 1 ] && [ "$NUM_ARCHS" -eq 1 ]; then
+    echo "${DISTROS_ARRAY[0]}/$VERSION/${ARCHS_ARRAY[0]}/*.btf.tar.xz" | tee "$SPARSE_CHECKOUT_FILE"
+elif [ "$NUM_DISTROS" -gt 1 ] && [ "$NUM_ARCHS" -eq 1 ]; then
+    for distro in "${DISTROS_ARRAY[@]}"; do
+        echo "$distro/*/${ARCHS_ARRAY[0]}/*.btf.tar.xz" | tee -a "$SPARSE_CHECKOUT_FILE"
+    done
+elif [ "$NUM_DISTROS" -eq 1 ] && [ "$NUM_ARCHS" -gt 1 ]; then
+    for arch in "${ARCHS_ARRAY[@]}"; do
+        echo "${DISTROS_ARRAY[0]}/*/$arch/*.btf.tar.xz" | tee -a "$SPARSE_CHECKOUT_FILE"
+    done
+else
+    for distro in "${DISTROS_ARRAY[@]}"; do
+        for arch in "${ARCHS_ARRAY[@]}"; do
+            echo "$distro/*/$arch/*.btf.tar.xz" | tee -a "$SPARSE_CHECKOUT_FILE"
+        done
+    done
+fi
+
 git -C "$ARCHIVE_DIR" sparse-checkout reapply || die "failed to reapply sparse-checkout"
 
 echo "Sparse checkout completed successfully in $ARCHIVE_DIR"


### PR DESCRIPTION
chore: multiple patterns for sparse-checkout

e.g.:

DISTRO="ubuntu centos" ./tools/archive-sparse-checkout.sh ARCH=x86_64 DISTRO="ubuntu centos" ./tools/archive-sparse-checkout.sh ARCH=arm64 VERSION=20.04 ./tools/archive-sparse-checkout.sh VERSION=20.04 ./tools/archive-sparse-checkout.sh