### PR TITLE
chore: public buster support end

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -177,11 +177,11 @@ jobs:
         run: |
           cd btfhub
           ./btfhub -workers 6 -d centos
-      # debian stretch seems to be gone, updates for buster and bullseye only
+      # public debian stretch and buster are gone, updates for bullseye only
+      # https://en.wikipedia.org/wiki/Debian_version_history#Release_table
       - name: Fetch and Generate new BTFs (DEBIAN)
         run: |
           cd btfhub
-          ./btfhub -workers 6 -d debian -r buster
           ./btfhub -workers 6 -d debian -r bullseye
       #
       - name: Fetch and Generate new BTFs (FEDORA)


### PR DESCRIPTION
commit ecfa1b009eb2df66f2e332ce959f1171ecc10c2e

    chore: public buster support end
    
    https://www.debian.org/News/2024/20240615
    https://en.wikipedia.org/wiki/Debian_version_history#Release_table