### PR TITLE
ci: phased archive cron, preflight/manifest, HTTP cache, docker toolc…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Speed up `docker build` from repo root (keep .git intact for `git submodule update` in Dockerfiles).
+**/archive/**/*.btf.tar.xz
+**/.btfhub-http-cache
+logs_*
+*.log

--- a/.github/actions/build-dependencies/action.yaml
+++ b/.github/actions/build-dependencies/action.yaml
@@ -13,21 +13,22 @@ inputs:
 runs:
   using: composite
   steps:
-    #
     - name: Install ubuntu packages
-      run: |
-        ./tests/install-deps.sh ${{ inputs.from }}
       shell: bash
       working-directory: ${{ inputs.run-on }}
-    #
+      env:
+        FROM: ${{ inputs.from }}
+        RUN_ON: ${{ inputs.run-on }}
+      run: |
+        set -euo pipefail
+        # shellcheck source=.github/scripts/ci-helpers.sh
+        source .github/scripts/ci-helpers.sh
+        validate_ref "from" "${FROM}"
+        validate_relative_workdir "run-on" "${RUN_ON}"
+        ./tests/install-deps.sh "${FROM}"
     - name: Install pahole
-      run: |
-        ./3rdparty/pahole.sh
       shell: bash
       working-directory: ${{ inputs.run-on }}
-    #
-    # - name: Install bpftool
-    #   run: |
-    #     ./3rdparty/bpftool.sh
-    #   shell: bash
-    #   working-directory: ${{ inputs.run-on }}
+      run: |
+        set -euo pipefail
+        ./3rdparty/pahole.sh

--- a/.github/actions/commit-push-archive/action.yaml
+++ b/.github/actions/commit-push-archive/action.yaml
@@ -1,0 +1,98 @@
+name: Commit and push BTFHub archive
+description: |
+  Commit local changes in the archive sparse checkout and push to GitHub.
+
+  Commit runs in a step without the push token; the token is only injected for a minimal follow-up
+  step that runs git push. Push uses HTTPS with Authorization via git --config-env (header passed
+  only for that invocation: GIT_AUTH_HEADER=... git push ..., not export). ::add-mask:: is applied to
+  the token and derived Basic auth material. Prefer a least-privilege PAT or a GitHub App
+  installation token for defense in depth.
+
+inputs:
+  working-directory:
+    description: Path to the archive git working tree (relative to the workspace)
+    required: true
+  author_email:
+    description: Git commit author email
+    required: true
+  author_name:
+    description: Git commit author name
+    required: true
+  commit_message:
+    description: Commit message when there are staged changes
+    required: false
+    default: "Update BTFHUB Archive from BTFHUB"
+  repository:
+    description: Target repository as owner/name
+    required: false
+    default: aquasecurity/btfhub-archive
+  branch:
+    description: Branch to push
+    required: false
+    default: main
+  github_token:
+    description: Token with contents:write on btfhub-archive (e.g. secrets.AQUASECURITY_BTFHUB_ARCHIVE_TOKEN)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Stage and commit
+      id: commit
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        INPUT_AUTHOR_EMAIL: ${{ inputs.author_email }}
+        INPUT_AUTHOR_NAME: ${{ inputs.author_name }}
+        INPUT_COMMIT_MESSAGE: ${{ inputs.commit_message }}
+        INPUT_REPOSITORY: ${{ inputs.repository }}
+        INPUT_WORKING_DIRECTORY: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+        # shellcheck source=.github/scripts/ci-helpers.sh
+        source "${GITHUB_WORKSPACE}/btfhub/.github/scripts/ci-helpers.sh"
+        validate_ref "repository" "${INPUT_REPOSITORY}"
+        validate_relative_workdir "working-directory" "${INPUT_WORKING_DIRECTORY}"
+
+        git config user.email "${INPUT_AUTHOR_EMAIL}"
+        git config user.name "${INPUT_AUTHOR_NAME}"
+        git remote set-url origin "https://github.com/${INPUT_REPOSITORY}.git"
+        git add -A
+        if git diff --cached --quiet; then
+            echo "No changes to commit"
+            set_output "should_push" "false"
+            exit 0
+        fi
+
+        git commit -m "${INPUT_COMMIT_MESSAGE}"
+        set_output "should_push" "true"
+
+    - name: Push to GitHub
+      if: steps.commit.outputs.should_push == 'true'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        ARCHIVE_PUSH_TOKEN: ${{ inputs.github_token }}
+        INPUT_BRANCH: ${{ inputs.branch }}
+      run: |
+        echo "::add-mask::${ARCHIVE_PUSH_TOKEN}"
+
+        set -euo pipefail
+        set +x
+        # shellcheck source=.github/scripts/ci-helpers.sh
+        source "${GITHUB_WORKSPACE}/btfhub/.github/scripts/ci-helpers.sh"
+        validate_ref "branch" "${INPUT_BRANCH}"
+
+        cleanup() {
+          unset ARCHIVE_PUSH_TOKEN auth header || true
+        }
+        trap cleanup EXIT
+
+        auth="$(printf 'x-access-token:%s' "${ARCHIVE_PUSH_TOKEN}" | base64 | tr -d '\n')"
+        echo "::add-mask::${auth}"
+
+        header="Authorization: Basic ${auth}"
+        echo "::add-mask::${header}"
+
+        GIT_AUTH_HEADER="${header}" \
+            git push --config-env=http.extraHeader=GIT_AUTH_HEADER origin "HEAD:${INPUT_BRANCH}"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
       - "/"
     schedule:
       interval: "daily"
+  # docker/Dockerfile.amazon and docker/Dockerfile.distros
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"

--- a/.github/scripts/ci-archive-collect-new.sh
+++ b/.github/scripts/ci-archive-collect-new.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Package new outputs for upload: non-empty *.btf.tar.xz, and
+# *.hasbtf / *.failed not in the prior path list.
+#
+# Usage: ci-archive-collect-new.sh LIST_FILE ARCHIVE_DIR OUT_DIR
+#
+
+set -euo pipefail
+
+list_file="${1:?usage: ci-archive-collect-new.sh LIST_FILE ARCHIVE_DIR OUT_DIR}"
+archive_dir="${2:?usage: ci-archive-collect-new.sh LIST_FILE ARCHIVE_DIR OUT_DIR}"
+out_dir="${3:?usage: ci-archive-collect-new.sh LIST_FILE ARCHIVE_DIR OUT_DIR}"
+
+rm -rf "${out_dir}"
+mkdir -p "${out_dir}"
+
+count=0
+while IFS= read -r -d '' f; do
+    rel="${f#"${archive_dir}/"}"
+    rel="${rel#./}"
+    case "${rel}" in
+        *.btf.tar.xz)
+            [[ -s "${f}" ]] || continue
+            ;;
+        *.hasbtf | *.failed)
+            if [[ -f "${list_file}" ]] && grep -Fxq "${rel}" "${list_file}" 2> /dev/null; then
+                continue
+            fi
+            ;;
+        *)
+            continue
+            ;;
+    esac
+    mkdir -p "${out_dir}/$(dirname "${rel}")"
+    cp -a "${f}" "${out_dir}/${rel}"
+    ((count++))
+done < <(find "${archive_dir}" -type f -print0 2> /dev/null || true)
+
+if ((count == 0)); then
+    echo "1" > "${out_dir}/.skip-push"
+    echo "No new BTF artifacts; created .skip-push"
+else
+    echo "Collected ${count} new file(s) under ${out_dir}"
+fi

--- a/.github/scripts/ci-archive-merge-for-push.sh
+++ b/.github/scripts/ci-archive-merge-for-push.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Copy collected artifact tree into the archive git checkout
+# (excludes .skip-push marker).
+#
+# Usage: ci-archive-merge-for-push.sh ARTIFACT_DIR ARCHIVE_CHECKOUT
+#
+
+set -euo pipefail
+
+src="${1:?usage: ci-archive-merge-for-push.sh ARTIFACT_DIR ARCHIVE_CHECKOUT}"
+dst="${2:?usage: ci-archive-merge-for-push.sh ARTIFACT_DIR ARCHIVE_CHECKOUT}"
+
+n=0
+while IFS= read -r -d '' f; do
+    rel="${f#"${src}/"}"
+    rel="${rel#./}"
+    mkdir -p "$(dirname "${dst}/${rel}")"
+    cp -a "${f}" "${dst}/${rel}"
+    ((n++))
+done < <(find "${src}" -type f ! -name '.skip-push' -print0 2> /dev/null || true)
+
+echo "Merged ${n} file(s) into ${dst}"

--- a/.github/scripts/ci-archive-placeholders.sh
+++ b/.github/scripts/ci-archive-placeholders.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Create empty placeholder files under archive_dir for every path listed.
+# btfhub skips kernels when *.btf.tar.xz exists (any size); markers
+# .hasbtf / .failed must match the repo layout.
+#
+# Usage: ci-archive-placeholders.sh LIST_FILE ARCHIVE_DIR
+#
+
+set -euo pipefail
+
+list_file="${1:?usage: ci-archive-placeholders.sh LIST_FILE ARCHIVE_DIR}"
+archive_dir="${2:?usage: ci-archive-placeholders.sh LIST_FILE ARCHIVE_DIR}"
+
+if [[ ! -f "${list_file}" ]]; then
+    echo "WARN: list file missing, skipping placeholders"
+    exit 0
+fi
+
+# Longest paths first: otherwise a line like ubuntu/xenial processed before
+# ubuntu/xenial/amd64/foo can leave ubuntu/xenial as a regular file and break
+# btfhub's MkdirAll(archive/ubuntu/xenial/x86_64).
+while IFS= read -r rel || [[ -n "${rel:-}" ]]; do
+    [[ -z "${rel}" ]] && continue
+    [[ "${rel}" =~ ^# ]] && continue
+    mkdir -p "$(dirname "${archive_dir}/${rel}")"
+    : > "${archive_dir}/${rel}"
+done < <(
+    awk 'NF && $0 !~ /^#/ { printf "%09d\t%s\n", length($0), $0 }' "${list_file}" \
+        | LC_ALL=C sort -r \
+        | cut -f2-
+)
+
+echo "Placeholders created under ${archive_dir}"

--- a/.github/scripts/ci-helpers.sh
+++ b/.github/scripts/ci-helpers.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+#
+# Reusable helpers for GitHub Actions: safe ref validation, GITHUB_OUTPUT writes,
+# job summaries ($GITHUB_STEP_SUMMARY), and GitHub API utilities.
+# Source this file in a step, then call the helpers as needed.
+#
+# Usage (in a workflow step):
+#   source .github/scripts/ci-helpers.sh
+#   validate_ref "field_name" "${SOME_REF}"
+#   validate_relative_workdir "run-on" "${RUN_ON}"
+#   validate_numeric "pr" "${SOME_PR}"
+#   set_output "output_name" "${VALUE}"
+#   { echo "## Section"; echo "line"; } | summary_append
+#   commit_subject "owner/repo" "${TOKEN}" "${SHA}"
+#
+
+# Validate a ref value: must be non-empty, single-line, alphanumeric with . _ - /
+# Arguments:
+#   $1 - name of the field (for error messages)
+#   $2 - value to validate
+validate_ref() {
+    local name="$1"
+    local value="$2"
+
+    if [[ -z "${value}" ]]; then
+        echo "::error::${name} is empty"
+        exit 1
+    fi
+
+    local clean
+    clean=$(printf '%s' "${value}" | tr -d '\n\r')
+    if [[ "${clean}" != "${value}" ]]; then
+        echo "::error::${name} contains newline characters (possible injection)"
+        exit 1
+    fi
+
+    if ! printf '%s' "${value}" | grep -qE '^[a-zA-Z0-9._/\-]+$'; then
+        echo "::error::${name} contains invalid characters: ${value}"
+        exit 1
+    fi
+}
+
+# Composite-action working-directory / run-on: ref-style chars plus no ".." or absolute paths.
+# Arguments:
+#   $1 - name of the field (for error messages)
+#   $2 - value to validate
+validate_relative_workdir() {
+    local name="$1"
+    local value="$2"
+
+    validate_ref "${name}" "${value}"
+    case "${value}" in
+        *..*)
+            echo "::error::${name} must not contain .. (path traversal)"
+            exit 1
+            ;;
+        /*)
+            echo "::error::${name} must be a relative path"
+            exit 1
+            ;;
+    esac
+}
+
+# Validate an optional numeric value (e.g. PR number): must be digits only.
+# Skips validation if the value is empty.
+# Arguments:
+#   $1 - name of the field (for error messages)
+#   $2 - value to validate
+validate_numeric() {
+    local name="$1"
+    local value="$2"
+
+    if [[ -n "${value}" ]] && ! [[ "${value}" =~ ^[0-9]+$ ]]; then
+        echo "::error::${name} must be a number, got: ${value}"
+        exit 1
+    fi
+}
+
+# Write an output safely using the delimiter form to prevent injection
+# Arguments:
+#   $1 - output name
+#   $2 - output value
+# Requires: GITHUB_OUTPUT set (e.g. in GitHub Actions)
+set_output() {
+    local name="$1"
+    local value="$2"
+    local delimiter
+
+    delimiter=$(od -An -tx1 -N16 /dev/urandom | tr -d ' \n')
+    {
+        echo "${name}<<${delimiter}"
+        echo "${value}"
+        echo "${delimiter}"
+    } >> "${GITHUB_OUTPUT}"
+}
+
+# Append markdown to the job summary (stdin). No-op if GITHUB_STEP_SUMMARY is unset.
+# Usage: summary_append <<'EOF'
+# ## My section
+# EOF
+summary_append() {
+    [[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0
+    cat >> "${GITHUB_STEP_SUMMARY}"
+}
+
+# Fetch the first line (subject) of a commit message via the GitHub API.
+# Returns an empty string on failure (best-effort).
+# Arguments:
+#   $1 - repository (owner/repo)
+#   $2 - GitHub token
+#   $3 - commit SHA or ref
+commit_subject() {
+    curl -fsS --connect-timeout 5 --max-time 10 \
+        -H "Authorization: token ${2}" \
+        -H "Accept: application/vnd.github+json" \
+        "https://api.github.com/repos/${1}/commits/${3}" 2> /dev/null \
+        | jq -r '.commit.message // "" | split("\n") | .[0] // ""' 2> /dev/null \
+        || true
+}

--- a/.github/scripts/fetch-archive-paths-github.py
+++ b/.github/scripts/fetch-archive-paths-github.py
@@ -1,0 +1,102 @@
+#!/usr/bin/python3
+"""List blob paths under a GitHub repo tree via REST API (no git clone).
+
+Works anonymously on public repos. Set GITHUB_TOKEN for higher rate limits.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument(
+        "output",
+        help="File to write (one repo-relative path per line)",
+    )
+    p.add_argument(
+        "prefixes",
+        nargs="+",
+        metavar="PREFIX",
+        help="Path prefixes to include (e.g. amzn/ centos/)",
+    )
+    p.add_argument(
+        "--owner",
+        default=os.environ.get("GITHUB_ARCHIVE_OWNER", "aquasecurity"),
+    )
+    p.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_ARCHIVE_REPO", "btfhub-archive"),
+    )
+    p.add_argument(
+        "--branch",
+        default=os.environ.get("GITHUB_ARCHIVE_BRANCH", "main"),
+    )
+    args = p.parse_args()
+
+    def get_json(url: str) -> dict:
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        token = os.environ.get("GITHUB_TOKEN")
+        if token:
+            req.add_header("Authorization", f"Bearer {token}")
+        try:
+            with urllib.request.urlopen(req, timeout=120) as resp:
+                return json.load(resp)
+        except urllib.error.HTTPError as e:
+            body = e.read().decode("utf-8", errors="replace")
+            print(f"HTTP {e.code} from {url}: {body}", file=sys.stderr)
+            raise SystemExit(1) from e
+
+    base = f"https://api.github.com/repos/{args.owner}/{args.repo}"
+    commit = get_json(f"{base}/commits/{args.branch}")
+    tree_sha = commit["commit"]["tree"]["sha"]
+    tree = get_json(f"{base}/git/trees/{tree_sha}?recursive=1")
+
+    if tree.get("truncated"):
+        print(
+            "error: git tree response truncated; narrow prefixes or paginate",
+            file=sys.stderr,
+        )
+        return 2
+
+    paths: list[str] = []
+    for item in tree.get("tree") or []:
+        if item.get("type") != "blob":
+            continue
+        path = item.get("path") or ""
+        if any(path.startswith(pref) for pref in args.prefixes):
+            paths.append(path)
+
+    out_dir = os.path.dirname(os.path.abspath(args.output))
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+
+    lines = [p + "\n" for p in sorted(set(paths))]
+    out_tmp = args.output + ".tmp"
+    try:
+        with open(out_tmp, "w", encoding="utf-8") as f:
+            f.writelines(lines)
+        os.replace(out_tmp, args.output)
+    except OSError:
+        if os.path.exists(out_tmp):
+            os.unlink(out_tmp)
+        raise
+
+    print(len(lines), args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/http-cache-summary.sh
+++ b/.github/scripts/http-cache-summary.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Emit markdown (stdout) for the BTFHUB_HTTP_CACHE job-summary section.
+# Args: optional cache directory; else BTFHUB_HTTP_CACHE; else btfhub/.btfhub-http-cache
+set -euo pipefail
+
+dir="${1:-${BTFHUB_HTTP_CACHE:-btfhub/.btfhub-http-cache}}"
+
+echo ""
+echo "### HTTP metadata cache (\`BTFHUB_HTTP_CACHE\`)"
+echo ""
+echo "Layout: **\`<sha256-of-URL>.body\`** (bytes as sent on the wire) + **\`<sha256>.meta\`** (JSON: \`etag\`, \`last_modified\`, \`content_type\`, \`content_encoding\`, \`final_url\`). Used by \`pkg/utils\` conditional GET."
+echo ""
+if [[ ! -d "${dir}" ]]; then
+    echo "*No cache directory at \`${dir}\` (nothing downloaded via this cache yet).*"
+    echo ""
+    exit 0
+fi
+
+n="$(find "${dir}" -type f \( -name '*.body' -o -name '*.meta' \) 2> /dev/null | wc -l | tr -d ' ')"
+sz="$(du -sh "${dir}" 2> /dev/null | awk '{print $1}')"
+echo "| Stat | Value |"
+echo "| --- | --- |"
+echo "| Path | \`${dir}\` |"
+echo "| Cache files (\`*.body\` / \`*.meta\`) | **${n}** |"
+echo "| Size (du -sh) | **${sz:-?}** |"
+echo ""
+echo "<details><summary>File list (temp \`*.part\` / \`*.tmp\` omitted)</summary>"
+echo ""
+echo '```text'
+mapfile -t files < <(find "${dir}" -maxdepth 1 -type f ! -name '*.part' ! -name '*.tmp' 2> /dev/null | sort)
+total="${#files[@]}"
+max=400
+i=0
+for f in "${files[@]}"; do
+    if [[ "${i}" -ge "${max}" ]]; then
+        echo "... and $((total - max)) more"
+        break
+    fi
+    basename "${f}"
+    i=$((i + 1))
+done
+echo '```'
+echo ""
+echo "</details>"
+echo ""

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,72 +1,165 @@
 name: Update BTFHub Archive
+# Default for any job without its own `permissions:`.
 permissions:
   contents: read
 on:
   schedule:
     - cron: "0 1 * * *"
   workflow_dispatch: {}
+
 jobs:
-  amazon-update:
-    name: Update Amazon 2 BTF Archive
-    runs-on: ubuntu-latest
-    container:
-      image: amazonlinux:2023
+  # --- Amazon: list paths -> generate (no PAT) -> push (PAT only) ---
+  amazon-list:
+    name: Amazon - list archive paths
+    permissions:
+      contents: read
+      actions: write # upload-artifact
+    runs-on: ubuntu-24.04
     steps:
-      - name: Install needed amazon packages
-        run: |
-          yum install -y yum-utils tar gzip xz clang make cmake git libdwarf-devel elfutils-libelf-devel elfutils-devel rsync
-        shell: bash
-      #
-      - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+      - name: Amazon - checkout scripts only
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          go-version: "1.25"
-      #
-      - name: Configure Git for HTTPS
+          sparse-checkout-cone-mode: true
+          sparse-checkout: |
+            .github/scripts
+      - name: Amazon - list paths in btfhub-archive (GitHub API, no clone)
+        shell: bash
         run: |
-          # Force Git to use HTTPS instead of SSH to avoid terminal auth prompts
+          set -euo pipefail
+          mkdir -p paths
+          python3 .github/scripts/fetch-archive-paths-github.py \
+              paths/existing-archive-paths.txt amzn/
+      - name: Amazon - upload path list
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: amazon-archive-paths
+          path: paths/
+          retention-days: 5
+      - name: Amazon - job summary
+        if: always()
+        shell: bash
+        env:
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_SERVER_URL: ${{ github.server_url }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          source .github/scripts/ci-helpers.sh
+          n="(missing)"
+          if [[ -f paths/existing-archive-paths.txt ]]; then
+              n="$(wc -l < paths/existing-archive-paths.txt | tr -d ' ')"
+          fi
+          run_url="${GH_SERVER_URL}/${GH_REPOSITORY}/actions/runs/${GH_RUN_ID}"
+          {
+              echo "## Amazon - list archive paths"
+              echo ""
+              echo "| Key | Value |"
+              echo "| --- | --- |"
+              echo "| Event | \`${GH_EVENT_NAME}\` |"
+              echo "| Ref / SHA | \`${GH_REF_NAME}\` / \`${GH_SHA}\` |"
+              echo "| Run | [${GH_RUN_ID}](${run_url}) |"
+              echo "| Indexed archive paths (\`amzn/\`) | **${n}** |"
+              echo "| Artifact | \`amazon-archive-paths\` (retention 5d) |"
+          } | summary_append
+
+  # Setup + preflight + conditional generate stay in one job: preflight runs ./btfhub against real
+  # repo metadata (needs this image, yum debug repos, built binary, placeholders). Splitting into
+  # separate jobs would either rebuild everything for "generate" or ship a large artifact (tree +
+  # /usr/local from pahole). Push is skipped when preflight needs no work or collect only wrote .skip-push.
+  amazon-generate:
+    name: Amazon - generate BTF archive
+    needs: amazon-list
+    permissions:
+      contents: read
+      actions: write # download-artifact + upload-artifact
+    runs-on: ubuntu-24.04
+    env:
+      # Per-URL HTTP cache for btfhub (SHA256 keys + conditional GET). AL2 path uses yum/repoquery
+      # for metadata; cache still helps any utils.Download/GetLinks traffic (e.g. RPM URLs).
+      BTFHUB_HTTP_CACHE: ${{ github.workspace }}/btfhub/.btfhub-http-cache
+    outputs:
+      needs_amazon: ${{ steps.preflight.outputs.needs_amazon }}
+      has_new_amazon_blobs: ${{ steps.push_gate.outputs.has_new_amazon_blobs }}
+    container:
+      # docker.io: same digest as Docker Hub; unprefixed "amazonlinux" breaks on Podman (resolves to ECR).
+      image: docker.io/library/amazonlinux:2023@sha256:162fc5b69e11e81023f83a1ab618b184927ff3002d0852432af3b6ae4a1b5304
+    steps:
+      - name: Amazon - install packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          yum install -y yum-utils tar gzip xz clang make cmake git \
+              libdwarf-devel elfutils-libelf-devel elfutils-devel rsync findutils
+      - name: Amazon - configure Git for HTTPS
+        shell: bash
+        run: |
+          set -euo pipefail
           git config --global url."https://github.com/".insteadOf "git@github.com:"
-        shell: bash
-      #
-      - name: Configure Go Proxy
-        run: |
-          # Ensure Go uses the public proxy to pull pre-indexed modules
-          # This bypasses the need for local git authentication for public repos
-          go env -w GOPROXY=https://proxy.golang.org,direct
-        shell: bash
-      #
-      - name: Setup Amazon Debuginfo Repositories
-        run: |
-          # disable default debuginfo repositories
-          yum-config-manager -y --disable amazonlinux-debuginfo
-
-          # add Amazon Linux 2 debuginfo repositories
-          append_repo() {
-            local arch=$1
-            local repo_name="amzn2-core-debuginfo-$arch"
-            
-            echo "[$repo_name]
-          name=Amazon Linux 2 core repository - debuginfo packages $arch
-          mirrorlist=http://amazonlinux.default.amazonaws.com/2/core/latest/debuginfo/$arch/mirror.list
-          enabled=1
-          "
-          }
-
-          cat << EOF >> /etc/yum.repos.d/amazonlinux.repo
-          $(append_repo "x86_64")
-          $(append_repo "aarch64")
-          EOF
-        shell: bash
-      #
-      - name: Checkout BTFHub
+      - name: Amazon - checkout BTFHub
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: aquasecurity/btfhub
           submodules: recursive
           path: ./btfhub
-      #
-      - name: Build and install pahole
+      - name: Amazon - restore/save HTTP metadata cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: btfhub/.btfhub-http-cache
+          key: btfhub-http-amazon-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            btfhub-http-amazon-
+      # Post-job cache save requires this path to exist; preflight may skip btfhub (no Download -> no MkdirAll).
+      - name: Amazon - ensure HTTP cache directory exists
+        shell: bash
+        run: mkdir -p btfhub/.btfhub-http-cache
+      - name: Amazon - set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: "1.26.1"
+          cache: true
+          cache-dependency-path: btfhub/go.sum
+      - name: Amazon - configure Go proxy
+        shell: bash
         run: |
+          set -euo pipefail
+          go env -w GOPROXY=https://proxy.golang.org,direct
+      - name: Amazon - setup debuginfo repositories
+        shell: bash
+        run: |
+          set -euo pipefail
+          yum-config-manager -y --disable amazonlinux-debuginfo
+          append_repo() {
+              local arch="$1"
+              local repo_name="amzn2-core-debuginfo-${arch}"
+              echo "[${repo_name}]
+          name=Amazon Linux 2 core repository - debuginfo packages ${arch}
+          mirrorlist=http://amazonlinux.default.amazonaws.com/2/core/latest/debuginfo/${arch}/mirror.list
+          enabled=1
+          "
+          }
+          cat << EOF >> /etc/yum.repos.d/amazonlinux.repo
+          $(append_repo "x86_64")
+          $(append_repo "aarch64")
+          EOF
+      - name: Amazon - download archive path list
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: amazon-archive-paths
+          path: archive-paths
+      - name: Amazon - placeholder existing archive files
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p btfhub/archive
+          bash btfhub/.github/scripts/ci-archive-placeholders.sh \
+              archive-paths/existing-archive-paths.txt btfhub/archive
+      - name: Amazon - build and install pahole
+        shell: bash
+        run: |
+          set -euo pipefail
           cd btfhub/3rdparty/dwarves
           mkdir build
           cd build
@@ -74,169 +167,649 @@ jobs:
           make install
           echo "/usr/local/lib" >> /etc/ld.so.conf.d/pahole.conf
           ldconfig
+      - name: Amazon - compile BTFHub tool
         shell: bash
-      #
-      # - name: Build and install bpftool
-      #   run: |
-      #     cd btfhub/3rdparty/bpftool
-      #     make -C src clean
-      #     CC=clang make -C src all
-      #     cp ./src/bpftool /usr/sbin/bpftool
-      #     make -C src clean
-      #   shell: bash
-      #
-      - name: Compile BTFHub Tool
         run: |
+          set -euo pipefail
           cd btfhub
           make
+      - name: Amazon - preflight (skip downloads when archive already has all kernels)
+        id: preflight
         shell: bash
-      #
-      - name: Checkout BTFHub Archive
+        run: |
+          set -euo pipefail
+          cd btfhub
+          # shellcheck source=.github/scripts/ci-helpers.sh
+          source .github/scripts/ci-helpers.sh
+          rm -f preflight-work.jsonl
+          set +e
+          ./btfhub -preflight -index ../archive-paths/existing-archive-paths.txt \
+              -manifest-out preflight-work.jsonl -d amzn -r 2
+          code=$?
+          set -e
+          if [[ "${code}" -eq 0 ]]; then
+              set_output "needs_amazon" "false"
+          elif [[ "${code}" -eq 1 ]]; then
+              set_output "needs_amazon" "true"
+          else
+              exit "${code}"
+          fi
+      - name: Amazon - fetch and generate BTFs (AL2)
+        id: amazon_generate_btfs
+        if: steps.preflight.outputs.needs_amazon == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd btfhub
+          ./btfhub -workers 6 -d amzn -r 2 -manifest preflight-work.jsonl
+      - name: Amazon - collect new artifacts for push
+        id: collect
+        if: steps.preflight.outputs.needs_amazon == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash btfhub/.github/scripts/ci-archive-collect-new.sh \
+              archive-paths/existing-archive-paths.txt btfhub/archive upload-btfs
+      - name: Amazon - gate push on new blobs (not .skip-push only)
+        id: push_gate
+        if: always()
+        env:
+          COLLECT_OUTCOME: ${{ steps.collect.outcome }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # shellcheck source=btfhub/.github/scripts/ci-helpers.sh
+          source btfhub/.github/scripts/ci-helpers.sh
+          if [[ "${COLLECT_OUTCOME}" != "success" ]]; then
+            set_output "has_new_amazon_blobs" "false"
+            exit 0
+          fi
+          if [[ -f upload-btfs/.skip-push ]]; then
+            set_output "has_new_amazon_blobs" "false"
+          else
+            set_output "has_new_amazon_blobs" "true"
+          fi
+      - name: Amazon - upload new BTF artifacts
+        id: amazon_upload_btfs
+        if: steps.collect.outcome == 'success' && steps.push_gate.outputs.has_new_amazon_blobs == 'true'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: amazon-new-btfs
+          path: upload-btfs/
+          retention-days: 5
+          # ci-archive-collect-new.sh uses .skip-push when there are no new blobs; upload-artifact v4+ skips dotfiles by default.
+          include-hidden-files: true
+      - name: Amazon - job summary
+        if: always()
+        shell: bash
+        env:
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_SERVER_URL: ${{ github.server_url }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_SHA: ${{ github.sha }}
+          NEEDS_AMAZON: ${{ steps.preflight.outputs.needs_amazon }}
+          HAS_NEW_AMAZON_BLOBS: ${{ steps.push_gate.outputs.has_new_amazon_blobs }}
+          PREFLIGHT_OUTCOME: ${{ steps.preflight.outcome }}
+          GENERATE_OUTCOME: ${{ steps.amazon_generate_btfs.outcome }}
+          COLLECT_OUTCOME: ${{ steps.collect.outcome }}
+          UPLOAD_OUTCOME: ${{ steps.amazon_upload_btfs.outcome }}
+        run: |
+          set -euo pipefail
+          # shellcheck source=.github/scripts/ci-helpers.sh
+          source btfhub/.github/scripts/ci-helpers.sh
+          run_url="${GH_SERVER_URL}/${GH_REPOSITORY}/actions/runs/${GH_RUN_ID}"
+          newc="-"
+          btf_archives="-"
+          sidecars="-"
+          if [[ -d upload-btfs ]]; then
+              newc="$(find upload-btfs -type f ! -name '.skip-push' 2> /dev/null | wc -l | tr -d ' ')"
+              btf_archives="$(find upload-btfs -type f -name '*.btf.tar.xz' 2> /dev/null | wc -l | tr -d ' ')"
+              sidecars="$(find upload-btfs -type f \( -name '*.hasbtf' -o -name '*.failed' \) 2> /dev/null | wc -l | tr -d ' ')"
+          fi
+          skip="-"
+          [[ -f upload-btfs/.skip-push ]] && skip="yes (no new blobs to push)"
+          {
+              echo "## Amazon - generate BTF archive"
+              echo ""
+              echo "| Key | Value |"
+              echo "| --- | --- |"
+              echo "| Event | \`${GH_EVENT_NAME}\` |"
+              echo "| Ref / SHA | \`${GH_REF_NAME}\` / \`${GH_SHA}\` |"
+              echo "| Run | [${GH_RUN_ID}](${run_url}) |"
+              echo "| Job output \`needs_amazon\` | \`${NEEDS_AMAZON:-}\` |"
+              echo "| Gate \`has_new_amazon_blobs\` (push job) | \`${HAS_NEW_AMAZON_BLOBS:-}\` |"
+              echo "| Step: preflight | \`${PREFLIGHT_OUTCOME}\` |"
+              echo "| Step: generate (\`amzn\` / AL2) | \`${GENERATE_OUTCOME}\` |"
+              echo "| Step: collect | \`${COLLECT_OUTCOME}\` |"
+              echo "| Step: upload artifact | \`${UPLOAD_OUTCOME}\` |"
+              echo "| New BTF archives (\`*.btf.tar.xz\`) | **${btf_archives}** |"
+              echo "| New sidecar files (\`*.hasbtf\` / \`*.failed\`) | **${sidecars}** |"
+              echo "| Total files in \`upload-btfs/\` (excl. \`.skip-push\`) | **${newc}** |"
+              echo "| \`.skip-push\` marker | ${skip} |"
+              echo "| Workers | 6 |"
+              bash btfhub/.github/scripts/http-cache-summary.sh "${BTFHUB_HTTP_CACHE:-btfhub/.btfhub-http-cache}"
+          } | summary_append
+
+  amazon-push:
+    name: Amazon - push BTF archive
+    needs: amazon-generate
+    if: >-
+      always()
+      && needs.amazon-generate.result == 'success'
+      && needs.amazon-generate.outputs.has_new_amazon_blobs == 'true'
+    permissions:
+      contents: read
+      actions: read # download-artifact only; push uses PAT secret
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Amazon - checkout BTFHub (actions + scripts only)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: aquasecurity/btfhub
+          path: ./btfhub
+          sparse-checkout-cone-mode: true
+          sparse-checkout: |
+            .github
+      - name: Amazon - checkout BTFHub archive
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: aquasecurity/btfhub-archive
-          token: ${{ secrets.GEYSLAN_BTFHUB_PAT }}
           persist-credentials: false
           fetch-depth: 1
           path: ./btfhub-archive
+          sparse-checkout-cone-mode: true
           sparse-checkout: |
             amzn
-      #
-      - name: Bring current BTFHub Archive
-        run: |
-          cd btfhub
-          make bring
-        shell: bash
-      #
-      - name: Fetch and Generate new BTFs (AMAZON 2)
-        run: |
-          cd btfhub
-          ./btfhub -workers 6 -d amzn -r 2
-      #
-      - name: Take new BTFs to BTFHub Archive
-        run: |
-          cd btfhub
-          make take
-      #
-      - name: Check Status
-        run: |
-          cd btfhub-archive
-          git status
-      #
-      - name: Commit and Push to BTFHub Archive
-        uses: actions-js/push@5a7cbd780d82c0c937b5977586e641b2fd94acc5 # v1.5
+      - name: Amazon - download new BTF artifacts
+        id: amazon_push_download
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          directory: ./btfhub-archive
-          author_email: 'geyslan@gmail.com'
-          author_name: 'Geyslan Gregório'
-          github_token: ${{ secrets.GEYSLAN_BTFHUB_PAT }}
-          message: 'Update BTFHUB Archive from BTFHUB'
-          repository: aquasecurity/btfhub-archive
-          branch: main
+          name: amazon-new-btfs
+          path: new-btfs
+      - name: Amazon - merge into archive checkout
+        id: merge
+        shell: bash
+        run: |
+          set -euo pipefail
+          # shellcheck source=.github/scripts/ci-helpers.sh
+          source ./btfhub/.github/scripts/ci-helpers.sh
+          if [[ -f new-btfs/.skip-push ]]; then
+              set_output "skip" "true"
+              echo "No new BTF artifacts to push."
+          else
+              bash ./btfhub/.github/scripts/ci-archive-merge-for-push.sh new-btfs btfhub-archive
+              set_output "skip" "false"
+          fi
+      - name: Amazon - commit and push to BTFHub archive
+        id: archive_amazon_commit_push
+        if: steps.merge.outputs.skip != 'true'
+        uses: ./btfhub/.github/actions/commit-push-archive
+        with:
+          working-directory: btfhub-archive
+          author_email: gg@condado.dev
+          author_name: Geyslan Gregório
+          github_token: ${{ secrets.AQUASECURITY_BTFHUB_ARCHIVE_TOKEN }}
+      - name: Amazon - job summary
+        if: always()
+        shell: bash
+        env:
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_SERVER_URL: ${{ github.server_url }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_SHA: ${{ github.sha }}
+          MERGE_SKIP: ${{ steps.merge.outputs.skip }}
+          MERGE_OUTCOME: ${{ steps.merge.outcome }}
+          DL_OUTCOME: ${{ steps.amazon_push_download.outcome }}
+          COMMIT_PUSH_OUTCOME: ${{ steps.archive_amazon_commit_push.outcome }}
+        run: |
+          set -euo pipefail
+          # shellcheck source=.github/scripts/ci-helpers.sh
+          source ./btfhub/.github/scripts/ci-helpers.sh
+          run_url="${GH_SERVER_URL}/${GH_REPOSITORY}/actions/runs/${GH_RUN_ID}"
+          {
+              echo "## Amazon - push BTF archive"
+              echo ""
+              echo "| Key | Value |"
+              echo "| --- | --- |"
+              echo "| Event | \`${GH_EVENT_NAME}\` |"
+              echo "| Ref / SHA | \`${GH_REF_NAME}\` / \`${GH_SHA}\` |"
+              echo "| Run | [${GH_RUN_ID}](${run_url}) |"
+              echo "| Target | \`aquasecurity/btfhub-archive\` (sparse \`amzn/\`) |"
+              echo "| Step: download artifact | \`${DL_OUTCOME}\` |"
+              echo "| Step: merge | \`${MERGE_OUTCOME}\` |"
+              echo "| Merge output \`skip\` | \`${MERGE_SKIP:-}\` |"
+              echo "| Step: commit && push | \`${COMMIT_PUSH_OUTCOME}\` |"
+          } | summary_append
 
-  build:
-    name: Update BTF Archive
+  # --- Other distros: same 3-phase split ---
+  distros-list:
+    name: Distros - list archive paths
+    permissions:
+      contents: read
+      actions: write # upload-artifact
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Distros - checkout scripts only
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout-cone-mode: true
+          sparse-checkout: |
+            .github/scripts
+      - name: Distros - list paths in btfhub-archive (GitHub API, no clone)
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p paths
+          python3 .github/scripts/fetch-archive-paths-github.py \
+              paths/existing-archive-paths.txt \
+              centos/ debian/ fedora/ ol/ ubuntu/
+      - name: Distros - upload path list
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: distros-archive-paths
+          path: paths/
+          retention-days: 5
+      - name: Distros - job summary
+        if: always()
+        shell: bash
+        env:
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_SERVER_URL: ${{ github.server_url }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          source .github/scripts/ci-helpers.sh
+          n="(missing)"
+          n_centos="-"
+          n_debian="-"
+          n_fedora="-"
+          n_ol="-"
+          n_ubuntu="-"
+          if [[ -f paths/existing-archive-paths.txt ]]; then
+              n="$(wc -l < paths/existing-archive-paths.txt | tr -d ' ')"
+              read -r n_centos n_debian n_fedora n_ol n_ubuntu < <(awk '
+                  /^centos\//  { c++ }
+                  /^debian\//  { d++ }
+                  /^fedora\//  { f++ }
+                  /^ol\//      { o++ }
+                  /^ubuntu\//  { u++ }
+                  END { print c + 0, d + 0, f + 0, o + 0, u + 0 }
+              ' paths/existing-archive-paths.txt)
+          fi
+          run_url="${GH_SERVER_URL}/${GH_REPOSITORY}/actions/runs/${GH_RUN_ID}"
+          {
+              echo "## Distros - list archive paths"
+              echo ""
+              echo "| Key | Value |"
+              echo "| --- | --- |"
+              echo "| Event | \`${GH_EVENT_NAME}\` |"
+              echo "| Ref / SHA | \`${GH_REF_NAME}\` / \`${GH_SHA}\` |"
+              echo "| Run | [${GH_RUN_ID}](${run_url}) |"
+              echo "| Indexed archive paths (all prefixes) | **${n}** |"
+              echo "| Paths \`centos/\` | **${n_centos}** |"
+              echo "| Paths \`debian/\` | **${n_debian}** |"
+              echo "| Paths \`fedora/\` | **${n_fedora}** |"
+              echo "| Paths \`ol/\` | **${n_ol}** |"
+              echo "| Paths \`ubuntu/\` | **${n_ubuntu}** |"
+              echo "| Artifact | \`distros-archive-paths\` (retention 5d) |"
+          } | summary_append
+
+  # Memory/disk-heavy on self-hosted runners (lost communication = often OOM/disk/full freeze).
+  # Graas: INSTANCE_TYPE=2XLARGE -> t3a.2xlarge / t4g.2xlarge + 250GB; btfhub uses 6 workers per distro.
+  distros-generate:
+    name: Distros - generate BTF archive
+    needs: distros-list
+    permissions:
+      contents: read
+      actions: write # download-artifact + upload-artifact
     env:
       HOME: "/tmp/root"
       GOPATH: "/tmp/go"
       GOCACHE: "/tmp/go-cache"
       GOROOT: "/usr/local/go"
-    # btf-80GiB-ubuntu-24.04-generic-6.11.0-29-x86_64
+      # Per-URL HTTP cache (Packages indices, repo HTML listings, package URLs) - see pkg/utils/http_cache.go
+      BTFHUB_HTTP_CACHE: ${{ github.workspace }}/btfhub/.btfhub-http-cache
     runs-on:
       - graas_ami-0b7b78bd2ebf4bb80_${{ github.event.number }}${{ github.run_attempt }}-${{ github.run_id }}
       - EXECUTION_TYPE=LONG
+      - INSTANCE_TYPE=2XLARGE
+    outputs:
+      needs_archive_push: ${{ steps.preflight.outputs.needs_centos == 'true' || steps.preflight.outputs.needs_debian == 'true' || steps.preflight.outputs.needs_fedora == 'true' || steps.preflight.outputs.needs_ol == 'true' || steps.preflight.outputs.needs_ubuntu == 'true' }}
+      has_new_distros_blobs: ${{ steps.push_gate.outputs.has_new_distros_blobs }}
     steps:
-      #
-      - name: Setup Swap File
+      - name: Distros - setup swap file
+        shell: bash
         run: |
+          set -euo pipefail
           fallocate -l 16G /swapfile
           chmod 600 /swapfile
           mkswap /swapfile
           swapon /swapfile
-        shell: bash
-      #
-      - name: Checkout BTFHub
+      - name: Distros - checkout BTFHub
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: aquasecurity/btfhub
           path: ./btfhub
-      #
-      - name: "Prepare Image (Fix AMI)"
+      - name: Distros - restore/save HTTP metadata cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: btfhub/.btfhub-http-cache
+          key: btfhub-http-distros-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            btfhub-http-distros-
+      # Post-job cache save requires this path to exist; preflight may skip all distros (no Download -> no MkdirAll).
+      - name: Distros - ensure HTTP cache directory exists
+        shell: bash
+        run: mkdir -p btfhub/.btfhub-http-cache
+      - name: Distros - prepare image (fix AMI)
         uses: ./btfhub/.github/actions/build-dependencies
         with:
           run-on: ./btfhub
           from: cron
-      #
-      - name: Checkout BTFHub Archive
+      - name: Distros - download archive path list
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: distros-archive-paths
+          path: archive-paths
+      - name: Distros - placeholder existing archive files
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p btfhub/archive
+          bash btfhub/.github/scripts/ci-archive-placeholders.sh \
+              archive-paths/existing-archive-paths.txt btfhub/archive
+      - name: Distros - compile BTFHub tool
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd btfhub
+          make
+      - name: Distros - preflight (skip downloads when archive already has all kernels)
+        id: preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd btfhub
+          # shellcheck source=.github/scripts/ci-helpers.sh
+          source .github/scripts/ci-helpers.sh
+          idx="../archive-paths/existing-archive-paths.txt"
+          rm -f preflight-work.jsonl
+          for entry in "centos:-d centos" "debian:-d debian -r bullseye" "fedora:-d fedora" "ol:-d ol" "ubuntu:-d ubuntu"; do
+              distro="${entry%%:*}"
+              args="${entry#*:}"
+              set +e
+              # shellcheck disable=SC2086
+              ./btfhub -preflight -index "${idx}" -manifest-out preflight-work.jsonl ${args}
+              code=$?
+              set -e
+              if [[ "${code}" -eq 1 ]]; then
+                  set_output "needs_${distro}" "true"
+              elif [[ "${code}" -eq 0 ]]; then
+                  set_output "needs_${distro}" "false"
+              else
+                  exit "${code}"
+              fi
+          done
+      - name: Distros - fetch & generate (centos)
+        id: gen_centos
+        if: steps.preflight.outputs.needs_centos == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd btfhub
+          ./btfhub -workers 6 -d centos -manifest preflight-work.jsonl
+      - name: Distros - fetch & generate (debian)
+        id: gen_debian
+        if: steps.preflight.outputs.needs_debian == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd btfhub
+          ./btfhub -workers 6 -d debian -r bullseye -manifest preflight-work.jsonl
+      - name: Distros - fetch & generate (fedora)
+        id: gen_fedora
+        if: steps.preflight.outputs.needs_fedora == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd btfhub
+          ./btfhub -workers 6 -d fedora -manifest preflight-work.jsonl
+      - name: Distros - fetch & generate (oracle)
+        id: gen_ol
+        if: steps.preflight.outputs.needs_ol == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd btfhub
+          ./btfhub -workers 6 -d ol -manifest preflight-work.jsonl
+      - name: Distros - fetch & generate (ubuntu)
+        id: gen_ubuntu
+        if: steps.preflight.outputs.needs_ubuntu == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd btfhub
+          ./btfhub -workers 6 -d ubuntu -manifest preflight-work.jsonl
+      - name: Distros - collect new artifacts for push
+        id: collect
+        if: >-
+          steps.preflight.outputs.needs_centos == 'true'
+          || steps.preflight.outputs.needs_debian == 'true'
+          || steps.preflight.outputs.needs_fedora == 'true'
+          || steps.preflight.outputs.needs_ol == 'true'
+          || steps.preflight.outputs.needs_ubuntu == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash btfhub/.github/scripts/ci-archive-collect-new.sh \
+              archive-paths/existing-archive-paths.txt btfhub/archive upload-btfs
+      - name: Distros - gate push on new blobs (not .skip-push only)
+        id: push_gate
+        if: always()
+        env:
+          COLLECT_OUTCOME: ${{ steps.collect.outcome }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # shellcheck source=btfhub/.github/scripts/ci-helpers.sh
+          source btfhub/.github/scripts/ci-helpers.sh
+          if [[ "${COLLECT_OUTCOME}" != "success" ]]; then
+            set_output "has_new_distros_blobs" "false"
+            exit 0
+          fi
+          if [[ -f upload-btfs/.skip-push ]]; then
+            set_output "has_new_distros_blobs" "false"
+          else
+            set_output "has_new_distros_blobs" "true"
+          fi
+      - name: Distros - upload new BTF artifacts
+        id: distros_upload_btfs
+        if: steps.collect.outcome == 'success' && steps.push_gate.outputs.has_new_distros_blobs == 'true'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: distros-new-btfs
+          path: upload-btfs/
+          retention-days: 5
+          # Same as Amazon: .skip-push is a dotfile; must be uploaded or push job cannot download-artifact.
+          include-hidden-files: true
+      - name: Distros - job summary
+        if: always()
+        shell: bash
+        env:
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_SERVER_URL: ${{ github.server_url }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_SHA: ${{ github.sha }}
+          RUNNER_RUN_ID: ${{ github.run_id }}
+          RUNNER_ATTEMPT: ${{ github.run_attempt }}
+          NEEDS_CENTOS: ${{ steps.preflight.outputs.needs_centos }}
+          NEEDS_DEBIAN: ${{ steps.preflight.outputs.needs_debian }}
+          NEEDS_FEDORA: ${{ steps.preflight.outputs.needs_fedora }}
+          NEEDS_OL: ${{ steps.preflight.outputs.needs_ol }}
+          NEEDS_UBUNTU: ${{ steps.preflight.outputs.needs_ubuntu }}
+          HAS_NEW_DISTROS_BLOBS: ${{ steps.push_gate.outputs.has_new_distros_blobs }}
+          PREFLIGHT_OUTCOME: ${{ steps.preflight.outcome }}
+          OUT_CENTOS: ${{ steps.gen_centos.outcome }}
+          OUT_DEBIAN: ${{ steps.gen_debian.outcome }}
+          OUT_FEDORA: ${{ steps.gen_fedora.outcome }}
+          OUT_OL: ${{ steps.gen_ol.outcome }}
+          OUT_UBUNTU: ${{ steps.gen_ubuntu.outcome }}
+          COLLECT_OUTCOME: ${{ steps.collect.outcome }}
+          UPLOAD_OUTCOME: ${{ steps.distros_upload_btfs.outcome }}
+        run: |
+          set -euo pipefail
+          # shellcheck source=.github/scripts/ci-helpers.sh
+          source btfhub/.github/scripts/ci-helpers.sh
+          run_url="${GH_SERVER_URL}/${GH_REPOSITORY}/actions/runs/${GH_RUN_ID}"
+          newc="-"
+          btf_archives="-"
+          sidecars="-"
+          if [[ -d upload-btfs ]]; then
+              newc="$(find upload-btfs -type f ! -name '.skip-push' 2> /dev/null | wc -l | tr -d ' ')"
+              btf_archives="$(find upload-btfs -type f -name '*.btf.tar.xz' 2> /dev/null | wc -l | tr -d ' ')"
+              sidecars="$(find upload-btfs -type f \( -name '*.hasbtf' -o -name '*.failed' \) 2> /dev/null | wc -l | tr -d ' ')"
+          fi
+          skip="-"
+          [[ -f upload-btfs/.skip-push ]] && skip="yes (no new blobs to push)"
+          {
+              echo "## Distros - generate BTF archive"
+              echo ""
+              echo "| Key | Value |"
+              echo "| --- | --- |"
+              echo "| Event | \`${GH_EVENT_NAME}\` |"
+              echo "| Ref / SHA | \`${GH_REF_NAME}\` / \`${GH_SHA}\` |"
+              echo "| Run | [${GH_RUN_ID}](${run_url}) |"
+              echo "| Run id / attempt | \`${RUNNER_RUN_ID}\` / \`${RUNNER_ATTEMPT}\` |"
+              echo "| Job output \`needs_archive_push\` | \`${{ steps.preflight.outputs.needs_centos == 'true' || steps.preflight.outputs.needs_debian == 'true' || steps.preflight.outputs.needs_fedora == 'true' || steps.preflight.outputs.needs_ol == 'true' || steps.preflight.outputs.needs_ubuntu == 'true' }}\` |"
+              echo "| Gate \`has_new_distros_blobs\` (push job) | \`${HAS_NEW_DISTROS_BLOBS:-}\` |"
+              echo "| Preflight step | \`${PREFLIGHT_OUTCOME}\` |"
+              echo ""
+              echo "### Preflight: work needed?"
+              echo ""
+              echo "| Distro | needs_* | Generate step |"
+              echo "| --- | --- | --- |"
+              echo "| centos | \`${NEEDS_CENTOS}\` | \`${OUT_CENTOS}\` |"
+              echo "| debian (bullseye) | \`${NEEDS_DEBIAN}\` | \`${OUT_DEBIAN}\` |"
+              echo "| fedora | \`${NEEDS_FEDORA}\` | \`${OUT_FEDORA}\` |"
+              echo "| ol | \`${NEEDS_OL}\` | \`${OUT_OL}\` |"
+              echo "| ubuntu | \`${NEEDS_UBUNTU}\` | \`${OUT_UBUNTU}\` |"
+              echo ""
+              echo "### Collect / upload"
+              echo ""
+              echo "| Step | Outcome |"
+              echo "| --- | --- |"
+              echo "| collect | \`${COLLECT_OUTCOME}\` |"
+              echo "| upload artifact | \`${UPLOAD_OUTCOME}\` |"
+              echo "| New BTF archives (\`*.btf.tar.xz\`) | **${btf_archives}** |"
+              echo "| New sidecar files (\`*.hasbtf\` / \`*.failed\`) | **${sidecars}** |"
+              echo "| Total files in \`upload-btfs/\` (excl. \`.skip-push\`) | **${newc}** |"
+              echo "| \`.skip-push\` | ${skip} |"
+              echo "| Workers per distro | 6 |"
+              bash btfhub/.github/scripts/http-cache-summary.sh "${BTFHUB_HTTP_CACHE:-btfhub/.btfhub-http-cache}"
+          } | summary_append
+
+  distros-push:
+    name: Distros - push BTF archive
+    needs: distros-generate
+    if: >-
+      always()
+      && needs.distros-generate.result == 'success'
+      && needs.distros-generate.outputs.has_new_distros_blobs == 'true'
+    permissions:
+      contents: read
+      actions: read # download-artifact only; push uses PAT secret
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Distros - checkout BTFHub (actions + scripts only)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: aquasecurity/btfhub
+          path: ./btfhub
+          sparse-checkout-cone-mode: true
+          sparse-checkout: |
+            .github
+      - name: Distros - checkout BTFHub archive
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: aquasecurity/btfhub-archive
-          token: ${{ secrets.GEYSLAN_BTFHUB_PAT }}
           persist-credentials: false
           fetch-depth: 1
           path: ./btfhub-archive
+          sparse-checkout-cone-mode: true
           sparse-checkout: |
             centos
             debian
             fedora
             ol
             ubuntu
-      #
-      - name: Bring current BTFHub Archive
-        run: |
-          cd btfhub
-          make bring
-        shell: bash
-      #
-      - name: Compile BTFHub Tool
-        run: |
-          cd btfhub
-          make
-        shell: bash
-      #
-      - name: Fetch and Generate new BTFs (CENTOS)
-        run: |
-          cd btfhub
-          ./btfhub -workers 6 -d centos
-      # public debian stretch and buster are gone, updates for bullseye only
-      # https://en.wikipedia.org/wiki/Debian_version_history#Release_table
-      - name: Fetch and Generate new BTFs (DEBIAN)
-        run: |
-          cd btfhub
-          ./btfhub -workers 6 -d debian -r bullseye
-      #
-      - name: Fetch and Generate new BTFs (FEDORA)
-        run: |
-          cd btfhub
-          ./btfhub -workers 6 -d fedora
-      #
-      - name: Fetch and Generate new BTFs (ORACLE)
-        run: |
-          cd btfhub
-          ./btfhub -workers 6 -d ol
-      #
-      - name: Fetch and Generate new BTFs (UBUNTU)
-        run: |
-          cd btfhub
-          ./btfhub -workers 6 -d ubuntu
-      #
-      - name: Take new BTFs to BTFHub Archive
-        run: |
-          cd btfhub
-          make take
-      #
-      - name: Check Status
-        run: |
-          cd btfhub-archive
-          git status
-      #
-      - name: Commit and Push to BTFHub Archive
-        uses: actions-js/push@5a7cbd780d82c0c937b5977586e641b2fd94acc5 # v1.5
+      - name: Distros - download new BTF artifacts
+        id: distros_push_download
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          directory: ./btfhub-archive
-          author_email: 'gg@condado.dev'
-          author_name: 'Geyslan Gregório'
-          github_token: ${{ secrets.GEYSLAN_BTFHUB_PAT }}
-          message: 'Update BTFHUB Archive from BTFHUB'
-          repository: aquasecurity/btfhub-archive
-          branch: main
+          name: distros-new-btfs
+          path: new-btfs
+      - name: Distros - merge into archive checkout
+        id: merge
+        shell: bash
+        run: |
+          set -euo pipefail
+          # shellcheck source=.github/scripts/ci-helpers.sh
+          source ./btfhub/.github/scripts/ci-helpers.sh
+          if [[ -f new-btfs/.skip-push ]]; then
+              set_output "skip" "true"
+              echo "No new BTF artifacts to push."
+          else
+              bash ./btfhub/.github/scripts/ci-archive-merge-for-push.sh new-btfs btfhub-archive
+              set_output "skip" "false"
+          fi
+      - name: Distros - commit and push to BTFHub archive
+        id: archive_distros_commit_push
+        if: steps.merge.outputs.skip != 'true'
+        uses: ./btfhub/.github/actions/commit-push-archive
+        with:
+          working-directory: btfhub-archive
+          author_email: gg@condado.dev
+          author_name: Geyslan Gregório
+          github_token: ${{ secrets.AQUASECURITY_BTFHUB_ARCHIVE_TOKEN }}
+      - name: Distros - job summary
+        if: always()
+        shell: bash
+        env:
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_SERVER_URL: ${{ github.server_url }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_SHA: ${{ github.sha }}
+          MERGE_SKIP: ${{ steps.merge.outputs.skip }}
+          MERGE_OUTCOME: ${{ steps.merge.outcome }}
+          DL_OUTCOME: ${{ steps.distros_push_download.outcome }}
+          COMMIT_PUSH_OUTCOME: ${{ steps.archive_distros_commit_push.outcome }}
+        run: |
+          set -euo pipefail
+          # shellcheck source=.github/scripts/ci-helpers.sh
+          source ./btfhub/.github/scripts/ci-helpers.sh
+          run_url="${GH_SERVER_URL}/${GH_REPOSITORY}/actions/runs/${GH_RUN_ID}"
+          {
+              echo "## Distros - push BTF archive"
+              echo ""
+              echo "| Key | Value |"
+              echo "| --- | --- |"
+              echo "| Event | \`${GH_EVENT_NAME}\` |"
+              echo "| Ref / SHA | \`${GH_REF_NAME}\` / \`${GH_SHA}\` |"
+              echo "| Run | [${GH_RUN_ID}](${run_url}) |"
+              echo "| Target | \`aquasecurity/btfhub-archive\` (sparse centos/debian/fedora/ol/ubuntu) |"
+              echo "| Step: download artifact | \`${DL_OUTCOME}\` |"
+              echo "| Step: merge | \`${MERGE_OUTCOME}\` |"
+              echo "| Merge output \`skip\` | \`${MERGE_SKIP:-}\` |"
+              echo "| Step: commit && push | \`${COMMIT_PUSH_OUTCOME}\` |"
+          } | summary_append

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,6 @@
 name: PR
+permissions:
+  contents: read
 on:
   workflow_dispatch: {}
   pull_request:
@@ -18,60 +20,60 @@ on:
       - "**.h"
       - "**.go"
       - "**.sh"
-      - ".github/workflows/pr.yaml"
+      - ".github/workflows/pr.yml"
 concurrency:
   group: ${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   verify-and-test:
     name: Verify and Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      #
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
-      #
       - name: Install Dependencies
         uses: ./.github/actions/build-dependencies
         with:
           from: pr
-      #
-      # CODE VERIFICATION
-      #
       - name: Install staticchecker
-        run: |
-          GOROOT=/usr/local/go GOPATH=$HOME/go go install honnef.co/go/tools/cmd/staticcheck@5af2e5fc3b08ba46027eb48ebddeba34dc0bd02c # 2025.1
-          sudo cp $HOME/go/bin/staticcheck /usr/bin/
         shell: bash
-      #
+        run: |
+          set -euo pipefail
+          GOROOT=/usr/local/go GOPATH="${HOME}/go" \
+              go install honnef.co/go/tools/cmd/staticcheck@ff63afafc529279f454e02f1d060210bd4263951 # v2026.1
+          sudo cp "${HOME}/go/bin/staticcheck" /usr/bin/
       - name: Install goimports-reviser
-        run: |
-          go install github.com/incu6us/goimports-reviser/v3@38044e6cb02749195e5384d9d9535ed00a10fc1f # v3.6.4
-          sudo cp $HOME/go/bin/goimports-reviser /usr/bin/
         shell: bash
-      #
+        run: |
+          set -euo pipefail
+          GOROOT=/usr/local/go GOPATH="${HOME}/go" \
+              go install github.com/incu6us/goimports-reviser/v3@fa5587e51ba33c58734984cb41370a5b2582d5b7 # v3.12.6
+          sudo cp "${HOME}/go/bin/goimports-reviser" /usr/bin/
       - name: Lint
+        shell: bash
         run: |
-          if test -z "$(gofmt -l .)"; then
-            echo "Congrats! There is nothing to fix."
+          set -euo pipefail
+          if [[ -z "$(gofmt -l .)" ]]; then
+              echo "Congrats! There is nothing to fix."
           else
-            echo "The following lines should be fixed."
-            gofmt -s -d .
-            exit 1
+              echo "The following lines should be fixed."
+              gofmt -s -d .
+              exit 1
           fi
-      #
       - name: Check Golang Vet
+        shell: bash
         run: |
+          set -euo pipefail
           make check-vet
-      #
       - name: Check with StaticCheck
+        shell: bash
         run: |
+          set -euo pipefail
           make check-staticcheck
-      #
-      # CODE TESTING
-      #
       - name: Run Unit Tests
+        shell: bash
         run: |
+          set -euo pipefail
           make test-unit

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ custom-archive/*
 .check*
 # JetBrains
 .idea/
+
+# Local BTFHUB_HTTP_CACHE (see pkg/utils/http_cache.go)
+.btfhub-http-cache/

--- a/3rdparty/pahole.sh
+++ b/3rdparty/pahole.sh
@@ -1,8 +1,13 @@
-#!/bin/bash -e
+#!/bin/bash
+#
+# Build and install pahole from the dwarves git submodule (Debian package workflow).
+#
+
+set -euo pipefail
 
 git submodule update --init --recursive 3rdparty/dwarves
 export DEBIAN_FRONTEND=noninteractive
-rm -f *.deb
+rm -f ./*.deb
 cd ./3rdparty/dwarves
 rm -rf ./debian/
 cp -rfp ../debian.dwarves/ ./debian/
@@ -12,4 +17,4 @@ fakeroot dh binary
 rm -rf ./debian/
 cd ..
 sudo dpkg -i ./pahole*.deb
-rm -f *.deb
+rm -f ./*.deb

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ GO_VERSION_MIN = $(shell echo $(GO_VERSION) | $(CMD_CUT) -d'.' -f2)
 	| .check_$(CMD_GO)
 #
 	@if [ ${GO_VERSION_MAJ} -eq 1 ]; then
-		if [ ${GO_VERSION_MIN} -lt 24 ]; then
-			echo -n "you MUST use golang 1.24 or newer, "
+		if [ ${GO_VERSION_MIN} -lt 26 ]; then
+			echo -n "you MUST use golang 1.26 or newer, "
 			echo "your current golang version is ${GO_VERSION}"
 			exit 1
 		fi
@@ -224,6 +224,47 @@ take: \
 	echo ""
 	echo "INFO: now goto $(BTFHUB_ARCHIVE_DIR) and commit the changes"
 	echo ""
+
+#
+# docker (local CI-like toolchains; see docker/README.md)
+#
+
+# BTFHUB_ARGS - flags for ./btfhub inside the container, e.g.:
+#   make docker-distros-btfhub BTFHUB_ARGS="-workers 4 -d debian -r bullseye"
+#   make docker-amazon-btfhub BTFHUB_ARGS="-workers 4 -d amzn -r 2"
+BTFHUB_ARGS ?=
+
+.PHONY: docker-distros-build docker-amazon-build \
+	docker-distros-bash docker-amazon-bash \
+	docker-distros-btfhub docker-amazon-btfhub \
+	docker-distros-make docker-amazon-make
+
+docker-distros-build:
+	docker build -f docker/Dockerfile.distros -t btfhub-distros:dev .
+
+docker-amazon-build:
+	docker build -f docker/Dockerfile.amazon -t btfhub-amazon:dev .
+
+# Interactive bash; repo is mounted at /btfhub (see docker/run-*.sh).
+docker-distros-bash:
+	./docker/run-distros.sh bash
+
+docker-amazon-bash:
+	./docker/run-amazon.sh bash
+
+# Build btfhub inside the image (same as one-shot ./docker/run-*.sh make).
+docker-distros-make:
+	./docker/run-distros.sh make
+
+docker-amazon-make:
+	./docker/run-amazon.sh make
+
+# Run the tool from the mounted tree; requires ./btfhub binary (run docker-*-make once).
+docker-distros-btfhub:
+	./docker/run-distros.sh ./btfhub $(BTFHUB_ARGS)
+
+docker-amazon-btfhub:
+	./docker/run-amazon.sh ./btfhub $(BTFHUB_ARGS)
 
 #
 # clean

--- a/README.md
+++ b/README.md
@@ -30,6 +30,26 @@ Please note that BTFhub's use is not universally necessary. If your intent is to
 
 This script then uses the BTFhub scripts to [generate tailored BTF files](docs/generating-tailored-btfs.md) that are exceptionally small in size. The result is a streamlined integration process and an efficient method for handling BTF files, demonstrating the power of BTFhub and its scripts when used effectively.
 
+## Running BTFHub locally
+
+### With Docker (any host)
+
+Use the local images that mirror CI: **`docker/run-distros.sh`**, **`docker/run-amazon.sh`**, and **`make docker-*`** (see **[docker/README.md](docker/README.md)** for Podman/Fedora, SELinux mounts, digest-pinned bases, `BTFHUB_HTTP_CACHE` defaults, and CI-style preflight snippets).
+
+### On the host
+
+From the repository root, with dependencies installed (see `Makefile` and `tests/install-deps.sh`), you can generate BTFs the same way CI does:
+
+- **Go**: `go.mod` requires **Go 1.26.1** (CI and `tests/install-deps.sh` use the same). With an older SDK and `GOTOOLCHAIN=local`, run `GOTOOLCHAIN=auto` or install Go 1.26.1+.
+
+- **Normal run** (no `-preflight`, no `-manifest`): `./btfhub -workers N -d <distro> ...` walks upstream metadata, then downloads and generates BTFs for every kernel that is missing from your local `archive/` tree (or passes `-f` to force redo). Nothing is special-cased for CI; **all fetch and generation runs from scratch** relative to what is already on disk under `archive/`.
+
+- **Archive paths vs. `-r`**: Under `archive/`, Ubuntu and Debian use directory names that match the **GitHub blob tree** in [btfhub-archive](https://github.com/aquasecurity/btfhub-archive) (e.g. `ubuntu/20.04/` while `-r focal`; `debian/10/` while `-r buster`). See [docs/btfhub-archive-path-layout.md](docs/btfhub-archive-path-layout.md).
+
+- **`-preflight` / `-manifest`**: **`-preflight`** needs **`-index path.txt`** (archive paths, one per line). Optional **`-manifest-out`** writes JSONL of kernels that would run (all distros); **`-manifest`** in normal mode restricts to that list. **`btfhub -h`** and [`.github/workflows/cron.yml`](.github/workflows/cron.yml) are canonical; a minimal host/container flow is under **Optional: match CI** in [docker/README.md](docker/README.md).
+
+- **`BTFHUB_HTTP_CACHE`**: optional directory for **metadata** HTTP caching (`Packages` indices, repo listings via `utils.Download` / `GetLinks`). **Large package downloads** (`DownloadFile`, e.g. `.rpm`/`.ddeb`) are **not** stored here. Default path when using `docker/run-*.sh` is under the mounted repo - see **Environment** in [docker/README.md](docker/README.md).
+
 ## More Information
 
 - [How to use Pahole to generate BTF information](https://github.com/aquasecurity/btfhub/blob/main/docs/how-to-use-pahole.md)

--- a/cmd/btfhub/main.go
+++ b/cmd/btfhub/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -10,12 +11,55 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"sort"
+	"strings"
 
 	"golang.org/x/sync/errgroup"
 
 	"github.com/aquasecurity/btfhub/pkg/job"
+	"github.com/aquasecurity/btfhub/pkg/manifest"
+	"github.com/aquasecurity/btfhub/pkg/preflight"
 	"github.com/aquasecurity/btfhub/pkg/repo"
 )
+
+// ubuntuArchiveDir maps APT codenames (used for downloads) to on-disk segments
+// under archive/ubuntu/ in btfhub-archive. The published repo lists blobs under
+// e.g. ubuntu/20.04/...; ubuntu/focal is only a symlink, so placeholders from the
+// GitHub tree would not be visible under ubuntu/focal/... and kernels looked
+// "missing" without this mapping.
+var ubuntuArchiveDir = map[string]string{
+	"xenial": "16.04",
+	"bionic": "18.04",
+	"focal":  "20.04",
+}
+
+// debianArchiveDir maps suite codenames (used for APT metadata) to on-disk
+// segments under archive/debian/ in btfhub-archive. The GitHub tree lists blobs
+// under debian/9, debian/10, debian/bullseye — not under stretch/buster.
+var debianArchiveDir = map[string]string{
+	"stretch":  "9",
+	"buster":   "10",
+	"bullseye": "bullseye",
+}
+
+// archiveLayoutDir returns the archive subdirectory name for (distro, release).
+func archiveLayoutDir(distro, release string) string {
+	if distro == "ubuntu" {
+		if d, ok := ubuntuArchiveDir[release]; ok {
+			return d
+		}
+	}
+	if distro == "debian" {
+		if d, ok := debianArchiveDir[release]; ok {
+			return d
+		}
+	}
+	return release
+}
+
+func archiveWorkDir(archiveRoot, distro, release, arch string) string {
+	return filepath.Join(archiveRoot, distro, archiveLayoutDir(distro, release), arch)
+}
 
 var distroReleases = map[string][]string{
 	"ubuntu": {"xenial", "bionic", "focal"},
@@ -44,6 +88,10 @@ var repoCreators = map[string]repoFunc{
 var distro, release, arch string
 var numWorkers int
 var force bool
+var preflightMode bool
+var indexFile string
+var manifestOut string
+var manifestIn string
 
 func init() {
 	flag.StringVar(&distro, "distro", "", "distribution to update (ubuntu,debian,centos,fedora,ol,rhel,amazon,sles)")
@@ -55,6 +103,10 @@ func init() {
 	flag.IntVar(&numWorkers, "workers", 0, "number of concurrent workers (defaults to runtime.NumCPU() - 1)")
 	flag.IntVar(&numWorkers, "j", 0, "number of concurrent workers (defaults to runtime.NumCPU() - 1)")
 	flag.BoolVar(&force, "f", false, "force update regardless of existing files (defaults to false)")
+	flag.BoolVar(&preflightMode, "preflight", false, "check if any kernel packages need processing vs index file; exit 0 if none, 1 if work needed (no downloads)")
+	flag.StringVar(&indexFile, "index", "", "path to archive path list (one repo-relative path per line); required with -preflight")
+	flag.StringVar(&manifestOut, "manifest-out", "", "with -preflight: append JSONL of every kernel that would be processed (all distros); exit 1 if any line written")
+	flag.StringVar(&manifestIn, "manifest", "", "normal mode: process only kernels listed in this JSONL (from preflight -manifest-out)")
 }
 
 func main() {
@@ -62,13 +114,83 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	if err := run(ctx); err != nil {
+	err := run(ctx)
+	if err != nil {
+		if preflightMode && errors.Is(err, preflight.ErrWorkFound) {
+			os.Exit(1)
+		}
 		log.Fatal(err)
+	}
+	if preflightMode {
+		// No packages need processing.
+		os.Exit(0)
 	}
 }
 
-func run(ctx context.Context) error {
+func materializeArchiveIndex(archiveDir, indexPath string) error {
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		return fmt.Errorf("read index: %w", err)
+	}
+	var lines []string
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	// Longest paths first so we never create a file at e.g. ubuntu/xenial before
+	// ubuntu/xenial/amd64/foo (which would leave xenial as a regular file and
+	// break MkdirAll for workDir ubuntu/xenial/x86_64).
+	sort.Slice(lines, func(i, j int) bool { return len(lines[i]) > len(lines[j]) })
+	for _, line := range lines {
+		p := filepath.Join(archiveDir, filepath.FromSlash(line))
+		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", filepath.Dir(p), err)
+		}
+		f, err := os.Create(p)
+		if err != nil {
+			return fmt.Errorf("create placeholder %s: %w", p, err)
+		}
+		if err := f.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
+// mkdirArchiveWorkDir creates workDir under archive, removing empty regular
+// files that would block a path component (e.g. CI placeholders created in
+// wrong order, or stale zero-byte stubs).
+func mkdirArchiveWorkDir(workDir string) error {
+	const perm = 0775
+	for attempts := 0; attempts < 128; attempts++ {
+		err := os.MkdirAll(workDir, perm)
+		if err == nil {
+			return nil
+		}
+		removed := false
+		for p := workDir; p != "/" && p != "."; p = filepath.Dir(p) {
+			st, err2 := os.Lstat(p)
+			if err2 != nil {
+				continue
+			}
+			if st.Mode().IsRegular() && st.Size() == 0 {
+				if rmErr := os.Remove(p); rmErr == nil {
+					removed = true
+					break
+				}
+			}
+		}
+		if !removed {
+			return err
+		}
+	}
+	return fmt.Errorf("mkdir %s: exhausted retries removing blocking stubs", workDir)
+}
+
+func validateDistroFlags() error {
 	if distro != "" {
 		if _, ok := distroReleases[distro]; !ok {
 			return fmt.Errorf("invalid distribution %s", distro)
@@ -76,8 +198,8 @@ func run(ctx context.Context) error {
 		if release != "" {
 			found := false
 			for _, r := range distroReleases[distro] {
-				found = r == release
-				if found {
+				if r == release {
+					found = true
 					break
 				}
 			}
@@ -86,24 +208,48 @@ func run(ctx context.Context) error {
 			}
 		}
 	} else {
-		release = "" // no release if no distro is selected
+		release = ""
+	}
+	return nil
+}
+
+func validateManifestFlags() error {
+	if preflightMode {
+		if manifestIn != "" {
+			return fmt.Errorf("-manifest cannot be used with -preflight")
+		}
+		return nil
+	}
+	if manifestOut != "" {
+		return fmt.Errorf("-manifest-out requires -preflight")
+	}
+	return nil
+}
+
+func run(ctx context.Context) error {
+	if err := validateDistroFlags(); err != nil {
+		return err
+	}
+	if err := validateManifestFlags(); err != nil {
+		return err
 	}
 
-	// Distributions
+	if preflightMode {
+		if indexFile == "" {
+			return fmt.Errorf("-preflight requires -index")
+		}
+		return runPreflight(ctx)
+	}
 
 	distros := []string{"ubuntu", "debian", "fedora", "centos", "ol"} // RHEL needs subscription
 	if distro != "" {
 		distros = []string{distro}
 	}
 
-	// Architectures
-
 	archs := []string{"x86_64", "arm64"}
 	if arch != "" {
 		archs = []string{arch}
 	}
-
-	// Environment
 
 	basedir, err := os.Getwd()
 	if err != nil {
@@ -111,14 +257,21 @@ func run(ctx context.Context) error {
 	}
 	archiveDir := path.Join(basedir, "archive")
 
-	if numWorkers == 0 {
-		numWorkers = runtime.NumCPU() - 1
-		if numWorkers > 12 {
-			numWorkers = 12 // limit to 12 workers max (for bigger machines)
+	var filt *manifest.Filter
+	if manifestIn != "" {
+		var lerr error
+		filt, lerr = manifest.LoadFilter(manifestIn)
+		if lerr != nil {
+			return lerr
 		}
 	}
 
-	// Workers: job consumers (pool)
+	if numWorkers == 0 {
+		numWorkers = runtime.NumCPU() - 1
+		if numWorkers > 12 {
+			numWorkers = 12
+		}
+	}
 
 	jobChan := make(chan job.Job)
 	consume, consCtx := errgroup.WithContext(ctx)
@@ -130,8 +283,78 @@ func run(ctx context.Context) error {
 		})
 	}
 
-	// Workers: job producers (per distro, per release)
+	produce, prodCtx := errgroup.WithContext(ctx)
+	if filt != nil {
+		prodCtx = manifest.WithFilter(prodCtx, filt)
+	}
 
+	for _, d := range distros {
+		releases := distroReleases[d]
+		if release != "" {
+			releases = []string{release}
+		}
+		for _, r := range releases {
+			release := r
+			for _, a := range archs {
+				arch := a
+				distro := d
+				produce.Go(func() error {
+					workDir := archiveWorkDir(archiveDir, distro, release, arch)
+					if err := mkdirArchiveWorkDir(workDir); err != nil {
+						return fmt.Errorf("arch dir: %s", err)
+					}
+					rp := repoCreators[distro]()
+					return rp.GetKernelPackages(prodCtx, workDir, release, arch, force, jobChan)
+				})
+			}
+		}
+	}
+
+	err = produce.Wait()
+	close(jobChan)
+	if err != nil {
+		return err
+	}
+
+	return consume.Wait()
+}
+
+func runPreflight(ctx context.Context) error {
+	ctx = preflight.WithContext(ctx)
+
+	var mw *manifest.Writer
+	if manifestOut != "" {
+		w, err := manifest.NewAppender(manifestOut)
+		if err != nil {
+			return fmt.Errorf("manifest-out: %w", err)
+		}
+		mw = w
+		defer func() { _ = mw.Close() }()
+	}
+
+	distros := []string{"ubuntu", "debian", "fedora", "centos", "ol"}
+	if distro != "" {
+		distros = []string{distro}
+	}
+
+	archs := []string{"x86_64", "arm64"}
+	if arch != "" {
+		archs = []string{arch}
+	}
+
+	basedir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("pwd: %s", err)
+	}
+	archiveDir := path.Join(basedir, "archive")
+	if err := os.RemoveAll(archiveDir); err != nil {
+		return fmt.Errorf("reset archive dir: %w", err)
+	}
+	if err := materializeArchiveIndex(archiveDir, indexFile); err != nil {
+		return err
+	}
+
+	jobChan := make(chan job.Job)
 	produce, prodCtx := errgroup.WithContext(ctx)
 
 	for _, d := range distros {
@@ -145,29 +368,33 @@ func run(ctx context.Context) error {
 				arch := a
 				distro := d
 				produce.Go(func() error {
-					// workDir example: ./archive/ubuntu/focal/x86_64
-					workDir := filepath.Join(archiveDir, distro, release, arch)
-					if err := os.MkdirAll(workDir, 0775); err != nil {
+					workDir := archiveWorkDir(archiveDir, distro, release, arch)
+					if err := mkdirArchiveWorkDir(workDir); err != nil {
 						return fmt.Errorf("arch dir: %s", err)
 					}
-
-					// pick the repository creator and get the kernel packages
-					repo := repoCreators[distro]()
-
-					return repo.GetKernelPackages(prodCtx, workDir, release, arch, force, jobChan)
+					subCtx := prodCtx
+					if mw != nil {
+						subCtx = manifest.WithWriter(subCtx, mw)
+						subCtx = manifest.WithTemplate(subCtx, manifest.Template{
+							Distro:  distro,
+							Release: release,
+							Arch:    arch,
+						})
+					}
+					rp := repoCreators[distro]()
+					return rp.GetKernelPackages(subCtx, workDir, release, arch, force, jobChan)
 				})
-
 			}
 		}
 	}
-
-	// Cleanup
 
 	err = produce.Wait()
 	close(jobChan)
 	if err != nil {
 		return err
 	}
-
-	return consume.Wait()
+	if mw != nil && mw.Count() > 0 {
+		return preflight.ErrWorkFound
+	}
+	return nil
 }

--- a/docker/Dockerfile.amazon
+++ b/docker/Dockerfile.amazon
@@ -1,0 +1,67 @@
+# syntax=docker/dockerfile:1
+
+# Use docker.io explicitly: Podman/Fedora short-name "amazonlinux" maps to public.ecr.aws,
+# where this Docker-Hub manifest digest is not available (manifest unknown).
+FROM docker.io/library/amazonlinux:2023@sha256:162fc5b69e11e81023f83a1ab618b184927ff3002d0852432af3b6ae4a1b5304
+
+# RUN uses POSIX /bin/sh (Docker default). Align with shell style: shfmt -p -i 4 -ci -bn -sr; shellcheck -s sh.
+ARG GO_VERSION=1.26.1
+
+RUN set -eu; \
+    yum install -y yum-utils tar gzip xz clang make cmake git \
+        libdwarf-devel elfutils-libelf-devel elfutils-devel rsync findutils \
+    && yum clean all
+
+RUN yum-config-manager -y --disable amazonlinux-debuginfo || true
+
+RUN set -eu; \
+    printf '%s\n' \
+        '' \
+        '[amzn2-core-debuginfo-x86_64]' \
+        'name=Amazon Linux 2 core repository - debuginfo packages x86_64' \
+        'mirrorlist=http://amazonlinux.default.amazonaws.com/2/core/latest/debuginfo/x86_64/mirror.list' \
+        'enabled=1' \
+        '' \
+        '[amzn2-core-debuginfo-aarch64]' \
+        'name=Amazon Linux 2 core repository - debuginfo packages aarch64' \
+        'mirrorlist=http://amazonlinux.default.amazonaws.com/2/core/latest/debuginfo/aarch64/mirror.list' \
+        'enabled=1' \
+        >> /etc/yum.repos.d/amazonlinux.repo
+
+RUN set -eu; \
+    arch="$(uname -m)"; \
+    case "${arch}" in \
+        x86_64) \
+            goarch=amd64 \
+            ;; \
+        aarch64) \
+            goarch=arm64 \
+            ;; \
+        *) \
+            echo "unsupported arch ${arch}" >&2; \
+            exit 1 \
+            ;; \
+    esac; \
+    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${goarch}.tar.gz" -o /tmp/go.tgz; \
+    rm -rf /usr/local/go; \
+    tar -C /usr/local -xzf /tmp/go.tgz; \
+    rm /tmp/go.tgz
+
+ENV PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV GOPROXY=https://proxy.golang.org,direct
+
+WORKDIR /btfhub
+COPY . .
+
+RUN git submodule update --init --recursive 3rdparty/dwarves
+
+RUN set -eu; \
+    cd 3rdparty/dwarves \
+    && mkdir -p build \
+    && cd build \
+    && cmake -D__LIB=lib -DDWARF_INCLUDE_DIR=/usr/include .. \
+    && make install \
+    && echo /usr/local/lib > /etc/ld.so.conf.d/pahole.conf \
+    && ldconfig
+
+WORKDIR /btfhub

--- a/docker/Dockerfile.distros
+++ b/docker/Dockerfile.distros
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+
+# Pinned digest for ubuntu:24.04 (resolved docker.io/library/ubuntu:24.04 @ 2026-03-20).
+FROM docker.io/library/ubuntu:24.04@sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c
+
+# RUN uses POSIX /bin/sh (Docker default). Align with shell style: shfmt -p -i 4 -ci -bn -sr; shellcheck -s sh.
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN set -eu; \
+    apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl git sudo psmisc procps \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /btfhub
+COPY . .
+
+RUN git submodule update --init --recursive 3rdparty/dwarves
+
+RUN ./tests/install-deps.sh pr
+
+RUN ./3rdparty/pahole.sh
+
+WORKDIR /btfhub

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,89 @@
+# Local Docker toolchains (mirror CI)
+
+CI runs **Amazon** in an **Amazon Linux 2023** job container and **CentOS / Debian / Fedora / Oracle / Ubuntu** on a **Ubuntu 24.04** self-hosted runner (`tests/install-deps.sh` + `3rdparty/pahole.sh`). These Dockerfiles reproduce those environments on any host.
+
+**Digest-pinned bases:** [`Dockerfile.amazon`](Dockerfile.amazon), [`Dockerfile.distros`](Dockerfile.distros) - bumps via Dependabot (`package-ecosystem: docker`, directory `/docker`). For **BTF / btfhub role** and **`btfhub` flags** overview, see the repo root [README.md](../README.md#running-btfhub-locally).
+
+## Prerequisites
+
+- Docker or **Podman** (`docker` CLI shim). On Fedora, Podman maps the short name `amazonlinux` to `public.ecr.aws`, which does not carry the same digest as Docker Hub - the Amazon image therefore uses **`docker.io/library/amazonlinux`** explicitly.
+- **Fedora / SELinux:** bind mounts default to `:z` so the container can read `/btfhub`. If you see `ls: cannot open directory '.': Permission denied` inside the container, ensure you’re on the updated `run-*.sh` scripts, or run with `chcon -Rt container_file_t ~/your/btfhub` once, or `BTFHUB_VOLUME_SUFFIX=""` only if your runtime errors on `:z`.
+- BuildKit recommended; images use `syntax=docker/dockerfile:1`.
+- **`Dockerfile.*` `RUN` shells** use POSIX `/bin/sh` (Docker default): `set -eu`, `${var}` quoting, `case` where it helps readability. When editing, copy a `RUN` body to a scratch `.sh` file and run `shfmt -p -i 4 -ci -bn -sr -w` and `shellcheck -s sh` (same idea as embedded YAML shell in the Tracee shell style guide).
+- Clone with submodules (or run `git submodule update --init --recursive` before `docker build`).
+
+### Makefile shortcuts (from repo root)
+
+```bash
+make docker-distros-bash          # shell in distros image
+make docker-amazon-bash           # shell in Amazon image
+make docker-distros-make          # build btfhub inside distros image
+make docker-amazon-make           # build inside Amazon image
+make docker-distros-btfhub BTFHUB_ARGS="-workers 4 -d debian -r bullseye"
+make docker-amazon-btfhub BTFHUB_ARGS="-workers 4 -d amzn -r 2"
+```
+
+Same as `./docker/run-*.sh`; extra env (e.g. `BTFHUB_VOLUME_SUFFIX=""`) still applies when you call the scripts directly or export it before `make`.
+
+## Distros (Ubuntu-based - CentOS, Debian, Fedora, OL, Ubuntu metadata)
+
+```bash
+chmod +x docker/run-distros.sh docker/run-amazon.sh   # once
+
+./docker/run-distros.sh bash
+# inside the container:
+make
+./btfhub -workers 4 -d debian -r bullseye
+```
+
+Or one-shot:
+
+```bash
+./docker/run-distros.sh make
+./docker/run-distros.sh ./btfhub -workers 4 -d ubuntu -r focal
+```
+
+The repo is bind-mounted at `/btfhub`, so edits on the host apply immediately. Tooling (Go **1.26.1** in the Amazon image, LLVM / `pahole` in the distros image) stays inside the image.
+
+**Note:** The image runs `tests/install-deps.sh pr` so LLVM is installed from apt. Upstream CI `cron` uses `install-deps.sh cron` on runners that already ship LLVM.
+
+## Amazon (Amazon Linux 2023 - `amzn` / AL2 debug RPMs)
+
+```bash
+./docker/run-amazon.sh bash
+# inside:
+make
+./btfhub -workers 4 -d amzn -r 2
+```
+
+## Optional: match CI preflight / placeholders
+
+Host-side sketch of what [`.github/workflows/cron.yml`](../.github/workflows/cron.yml) does before generate (path list -> placeholders -> **`btfhub -preflight -index ...`** -> optional **`-manifest-out`**). **Flag meanings:** root [README.md](../README.md#running-btfhub-locally) and **`btfhub -h`**.
+
+```bash
+# On the host (needs python3 + urllib; script shebang is /usr/bin/python3)
+mkdir -p paths
+python3 .github/scripts/fetch-archive-paths-github.py paths/existing-archive-paths.txt ubuntu/
+bash .github/scripts/ci-archive-placeholders.sh paths/existing-archive-paths.txt archive
+```
+
+In the container, point **`-index`** at that path list for **`-preflight`**; use **`-manifest-out`** / **`-manifest`** as in the workflow.
+
+## Environment
+
+- **`BTFHUB_HTTP_CACHE`** - defaults to `/btfhub/.btfhub-http-cache` in the container (same bind mount as the repo, so it persists on the host). Override:  
+  `BTFHUB_HTTP_CACHE=/tmp/cache ./docker/run-distros.sh ./btfhub ...`  
+  What is cached (metadata vs packages): root [README.md](../README.md#running-btfhub-locally).
+
+## Resource expectations
+
+Full-archive runs are **heavy** (disk, RAM, network). For local use, narrow with `-d`, `-r`, `-workers`, or a manifest from `-preflight`.
+
+## Image tags
+
+Override the image name when building or running:
+
+```bash
+docker build -f docker/Dockerfile.distros -t my-btfhub:distros .
+IMAGE=my-btfhub:distros ./docker/run-distros.sh bash
+```

--- a/docker/run-amazon.sh
+++ b/docker/run-amazon.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Run a command inside the Amazon Linux 2023 toolchain image (AL2 debuginfo repos + pahole).
+# Examples:
+#   ./docker/run-amazon.sh bash
+#   ./docker/run-amazon.sh make
+#   ./docker/run-amazon.sh ./btfhub -workers 4 -d amzn -r 2
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+IMAGE=${IMAGE:-btfhub-amazon:dev}
+
+if ! docker image inspect "$IMAGE" &> /dev/null; then
+    echo "Image $IMAGE not found; building..." >&2
+    docker build -f "${ROOT}/docker/Dockerfile.amazon" -t "$IMAGE" "$ROOT"
+fi
+
+: "${BTFHUB_HTTP_CACHE:=/btfhub/.btfhub-http-cache}"
+: "${BTFHUB_VOLUME_SUFFIX=:z}" # SELinux / Podman on Fedora; clear with BTFHUB_VOLUME_SUFFIX=""
+
+exec docker run --rm -it \
+    -v "${ROOT}:/btfhub${BTFHUB_VOLUME_SUFFIX}" \
+    -w /btfhub \
+    -e BTFHUB_HTTP_CACHE \
+    "$IMAGE" "$@"

--- a/docker/run-distros.sh
+++ b/docker/run-distros.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Run a command inside the distros (Ubuntu) toolchain image with this repo mounted at /btfhub.
+# Examples:
+#   ./docker/run-distros.sh bash
+#   ./docker/run-distros.sh make
+#   ./docker/run-distros.sh ./btfhub -workers 4 -d ubuntu -r focal
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+IMAGE=${IMAGE:-btfhub-distros:dev}
+
+if ! docker image inspect "$IMAGE" &> /dev/null; then
+    echo "Image $IMAGE not found; building..." >&2
+    docker build -f "${ROOT}/docker/Dockerfile.distros" -t "$IMAGE" "$ROOT"
+fi
+
+: "${BTFHUB_HTTP_CACHE:=/btfhub/.btfhub-http-cache}"
+# :z = SELinux shared label on the bind mount (Fedora/Podman: fixes "Permission denied" on /btfhub).
+# Override with BTFHUB_VOLUME_SUFFIX="" if your runtime rejects the suffix.
+: "${BTFHUB_VOLUME_SUFFIX=:z}"
+
+exec docker run --rm -it \
+    -v "${ROOT}:/btfhub${BTFHUB_VOLUME_SUFFIX}" \
+    -w /btfhub \
+    -e BTFHUB_HTTP_CACHE \
+    -e HOME=/tmp/root \
+    -e GOPATH=/tmp/go \
+    -e GOCACHE=/tmp/go-cache \
+    "$IMAGE" "$@"

--- a/docs/btfhub-archive-path-layout.md
+++ b/docs/btfhub-archive-path-layout.md
@@ -1,0 +1,30 @@
+# btfhub-archive path layout (vs. btfhub `-r` releases)
+
+BTFHub passes an **APT/YUM release id** into `GetKernelPackages` (e.g. Ubuntu
+`focal`, Debian `buster`). Published BTFs in
+[btfhub-archive](https://github.com/aquasecurity/btfhub-archive) use **different
+middle path segments** in many cases. CI builds placeholders from the GitHub
+**blob** tree; symlinks or alternate codename dirs are **not** listed as blobs,
+so `btfhub` must write under the same segments the tree uses.
+
+Path stats below come from a **recursive tree listing** (no clone / no blob
+download), e.g.:
+
+```bash
+python3 .github/scripts/fetch-archive-paths-github.py /tmp/paths.txt \
+    ubuntu/ debian/ fedora/ centos/ ol/ amzn/
+# then inspect unique $distro/$release/ prefixes
+```
+
+## Summary
+
+| Distro  | btfhub `-r` values              | Archive dir segment   | Notes                                      |
+|---------|----------------------------------|-----------------------|--------------------------------------------|
+| ubuntu  | xenial, bionic, focal            | 16.04, 18.04, 20.04   | Blobs under numeric dirs; codename symlinks|
+| debian  | stretch, buster, bullseye        | 9, 10, bullseye       | stretch/buster dirs barely used vs 9/10    |
+| fedora  | 24 ... 31                          | same                  | OK                                         |
+| centos  | 7, 8                             | same                  | OK                                         |
+| ol      | 7, 8                             | same                  | OK                                         |
+| amzn    | 1, 2                             | same (+ `2018`, ...)    | AL2 uses `2`; other tags exist in archive  |
+
+Mapping is implemented in `cmd/btfhub/main.go` (`archiveLayoutDir`).

--- a/docs/generating-tailored-btfs.md
+++ b/docs/generating-tailored-btfs.md
@@ -37,7 +37,7 @@ The BTFGEN was later [incorporated](https://lore.kernel.org/bpf/20220215225856.6
     Updating files: 100% (863/863), done.
     ```
 
-2. Enter `btfhub` directory and bring the cloned arquive into the `btfhub` directory:
+2. Enter the `btfhub` directory and bring the cloned **btfhub-archive** into `btfhub`’s `archive/` tree:
 
     ```
     $ cd btfhub ; ls

--- a/docs/how-to-use-pahole.md
+++ b/docs/how-to-use-pahole.md
@@ -54,9 +54,9 @@ By choosing either of these methods, you can effectively generate BTF informatio
 
 ## How does the Linux kernel generate its own BTF information ?
 
-The central premise of [BTFhub](https://github.com/aquasecurity/btfhub/) and [BTFhub-Archive](https://github.com/aquasecurity/btfhub-archive/) revolves around the automation of kernel debugging package conversion to BTF information, which is vital for libbpf to operate CO-RE capable eBPF applications. This is achieved by the [btfhub](https://github.com/aquasecurity/btfhub/blob/main/cmd/btfhub/main.go) application (compiled through `make`), [which downloads all existing debug kernel packages for the supported distributions and subsequently converts the embedded DWARF information into BTF format.](https://github.com/aquasecurity/btfhub/blob/f37a9cdc160f3add77a24beb6512dbb4557bc728/.github/workflows/cron.yml)
+The central premise of [BTFhub](https://github.com/aquasecurity/btfhub/) and [BTFhub-Archive](https://github.com/aquasecurity/btfhub-archive/) revolves around the automation of kernel debugging package conversion to BTF information, which is vital for libbpf to operate CO-RE capable eBPF applications. This is achieved by the [btfhub](https://github.com/aquasecurity/btfhub/blob/main/cmd/btfhub/main.go) application (compiled through `make`), [orchestrated by the scheduled GitHub Actions workflow](https://github.com/aquasecurity/btfhub/blob/main/.github/workflows/cron.yml), which lists existing archive paths, runs preflight, generates missing BTFs in container jobs, and pushes new blobs to the archive.
 
-BTFhub operates the `btfhub` application in a manner similar to a cron job, executing it daily. The generated BTF files are then uploaded into the [BTFhub-Archive repository](https://github.com/aquasecurity/btfhub-archive/), where they can be consumed by your project.
+That workflow is triggered on a **schedule** (cron). New BTF artifacts land in [BTFhub-Archive](https://github.com/aquasecurity/btfhub-archive/) via the workflow’s push steps, where projects can consume them.
 
 1. For hands-on experience, you can add a .BTF ELF section to the non-stripped vmlinuz (uncompressed) kernel file by executing:
 

--- a/docs/supported-distros.md
+++ b/docs/supported-distros.md
@@ -6,7 +6,7 @@ and **BTF** supportability over their kernel versions.
 > It is **highly recommended** that you update to your latest distribution's
 > kernel version in order to use eBPF latest available features.
 
-In the tables bellow you will find BPF, BTF and HUB columns:
+In the tables below you will find BPF, BTF and HUB columns:
 
 * BPF - kernel has support for BPF programs (with or without embedded BTF info)
 * BTF - kernel is compiled with DEBUG_INFO_BTF (/sys/kernel/btf/vmlinux avail)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aquasecurity/btfhub
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/DataDog/zstd v1.5.7

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -1,0 +1,174 @@
+// Package manifest supports recording kernel packages that need work during
+// preflight (JSONL) and filtering the generate pass to only those entries.
+package manifest
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+type ctxWriterKey struct{}
+type ctxTemplateKey struct{}
+type ctxFilterKey struct{}
+
+// Template identifies one (distro, release, arch) plane for manifest lines.
+type Template struct {
+	Distro  string
+	Release string
+	Arch    string
+}
+
+// Entry is one JSONL record (Ubuntu: name_of_file is BTFFilename / kernel stem).
+type Entry struct {
+	Distro     string `json:"distro"`
+	Release    string `json:"release"`
+	Arch       string `json:"arch"`
+	NameOfFile string `json:"name_of_file"`
+}
+
+// Writer appends JSONL lines (thread-safe). Count is the number of Append calls
+// in this process (used for preflight exit status).
+type Writer struct {
+	mu    sync.Mutex
+	f     *os.File
+	enc   *json.Encoder
+	count atomic.Int64
+}
+
+// NewAppender opens path for append (and create). Caller must Close.
+func NewAppender(path string) (*Writer, error) {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+	w := &Writer{f: f, enc: json.NewEncoder(f)}
+	return w, nil
+}
+
+func (w *Writer) Append(t Template, nameOfFile string) error {
+	if nameOfFile == "" {
+		return errors.New("manifest: empty name_of_file")
+	}
+	e := Entry{Distro: t.Distro, Release: t.Release, Arch: t.Arch, NameOfFile: nameOfFile}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if err := w.enc.Encode(e); err != nil {
+		return err
+	}
+	w.count.Add(1)
+	return nil
+}
+
+func (w *Writer) Count() int64 {
+	return w.count.Load()
+}
+
+func (w *Writer) Close() error {
+	if w == nil || w.f == nil {
+		return nil
+	}
+	return w.f.Close()
+}
+
+// WithWriter attaches a manifest writer to ctx (used with preflight).
+func WithWriter(ctx context.Context, w *Writer) context.Context {
+	return context.WithValue(ctx, ctxWriterKey{}, w)
+}
+
+// WriterFromContext returns the writer, or nil.
+func WriterFromContext(ctx context.Context) *Writer {
+	v, _ := ctx.Value(ctxWriterKey{}).(*Writer)
+	return v
+}
+
+// WithTemplate attaches distro/release/arch for manifest lines.
+func WithTemplate(ctx context.Context, t Template) context.Context {
+	return context.WithValue(ctx, ctxTemplateKey{}, t)
+}
+
+// TemplateFromContext returns the template and whether it was set.
+func TemplateFromContext(ctx context.Context) (Template, bool) {
+	t, ok := ctx.Value(ctxTemplateKey{}).(Template)
+	return t, ok
+}
+
+// Filter matches (distro, release, arch, name_of_file) keys from a manifest file.
+type Filter struct {
+	keys map[string]struct{}
+}
+
+func makeKey(distro, release, arch, nameOfFile string) string {
+	var b strings.Builder
+	b.Grow(len(distro) + len(release) + len(arch) + len(nameOfFile) + 8)
+	b.WriteString(distro)
+	b.WriteByte(0)
+	b.WriteString(release)
+	b.WriteByte(0)
+	b.WriteString(arch)
+	b.WriteByte(0)
+	b.WriteString(nameOfFile)
+	return b.String()
+}
+
+// LoadFilter reads JSONL manifest from path. An empty file yields a filter
+// that matches nothing. The file must exist.
+func LoadFilter(path string) (*Filter, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	keys := make(map[string]struct{})
+	sc := bufio.NewScanner(f)
+	// Long lines for safety
+	buf := make([]byte, 0, 64*1024)
+	sc.Buffer(buf, 1024*1024)
+
+	lineNo := 0
+	for sc.Scan() {
+		lineNo++
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var e Entry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			return nil, fmt.Errorf("manifest line %d: %w", lineNo, err)
+		}
+		if e.Distro == "" || e.Release == "" || e.Arch == "" || e.NameOfFile == "" {
+			return nil, fmt.Errorf("manifest line %d: missing field", lineNo)
+		}
+		keys[makeKey(e.Distro, e.Release, e.Arch, e.NameOfFile)] = struct{}{}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return &Filter{keys: keys}, nil
+}
+
+func (f *Filter) Match(distro, release, arch, nameOfFile string) bool {
+	if f == nil || f.keys == nil {
+		return true
+	}
+	_, ok := f.keys[makeKey(distro, release, arch, nameOfFile)]
+	return ok
+}
+
+// WithFilter attaches a filter (may be nil = no filtering).
+func WithFilter(ctx context.Context, f *Filter) context.Context {
+	return context.WithValue(ctx, ctxFilterKey{}, f)
+}
+
+// FilterFromContext returns the filter, or nil if unset (treat as no filter).
+func FilterFromContext(ctx context.Context) *Filter {
+	v, _ := ctx.Value(ctxFilterKey{}).(*Filter)
+	return v
+}

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -1,0 +1,51 @@
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriterAppendAndLoadFilter(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "m.jsonl")
+
+	w, err := NewAppender(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := Template{Distro: "ubuntu", Release: "focal", Arch: "x86_64"}
+	if err := w.Append(tmpl, "5.4.0-1-generic"); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Append(tmpl, "5.4.0-2-generic"); err != nil {
+		t.Fatal(err)
+	}
+	if w.Count() != 2 {
+		t.Fatalf("count = %d", w.Count())
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := LoadFilter(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !f.Match("ubuntu", "focal", "x86_64", "5.4.0-1-generic") {
+		t.Fatal("expected match")
+	}
+	if f.Match("ubuntu", "focal", "x86_64", "5.4.0-9-generic") {
+		t.Fatal("unexpected match")
+	}
+	if f.Match("ubuntu", "bionic", "x86_64", "5.4.0-1-generic") {
+		t.Fatal("unexpected match on release")
+	}
+}
+
+func TestLoadFilterMissing(t *testing.T) {
+	_, err := LoadFilter(filepath.Join(t.TempDir(), "nope.jsonl"))
+	if err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expected IsNotExist, got %v", err)
+	}
+}

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -1,0 +1,24 @@
+package preflight
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrWorkFound is returned when a kernel package would be processed (download +
+// BTF generation) in normal mode. Used only with FromContext(ctx) == true.
+var ErrWorkFound = errors.New("preflight: archive needs updates for at least one kernel package")
+
+type ctxKey struct{}
+
+// WithContext marks ctx so processPackage stops before enqueueing jobs and
+// returns ErrWorkFound when a package would otherwise be processed.
+func WithContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxKey{}, true)
+}
+
+// FromContext reports whether preflight (no job enqueue) is active.
+func FromContext(ctx context.Context) bool {
+	v, _ := ctx.Value(ctxKey{}).(bool)
+	return v
+}

--- a/pkg/repo/amazon.go
+++ b/pkg/repo/amazon.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aquasecurity/btfhub/pkg/job"
 	"github.com/aquasecurity/btfhub/pkg/kernel"
 	"github.com/aquasecurity/btfhub/pkg/pkg"
+	"github.com/aquasecurity/btfhub/pkg/preflight"
 	"github.com/aquasecurity/btfhub/pkg/utils"
 )
 
@@ -52,15 +53,34 @@ func (d *AmazonRepo) GetKernelPackages(
 	}
 	sort.Sort(pkg.ByVersion(pkgs))
 
-	for _, pkg := range pkgs {
+	pkgs = filterPackagesByManifest(ctx, "amzn", release, arch, pkgs)
+
+	for i, pkg := range pkgs {
+		log.Printf("DEBUG: start pkg %s (%d/%d)\n", pkg, i+1, len(pkgs))
+
+		// Jobs about to be created:
+		//
+		// 1. Download package and extract vmlinux file
+		// 2. Extract BTF info from vmlinux file
+
 		err := processPackage(ctx, pkg, workDir, force, jobChan)
 		if err != nil {
+			if errors.Is(err, preflight.ErrWorkFound) {
+				return err
+			}
 			if errors.Is(err, utils.ErrHasBTF) {
 				log.Printf("INFO: kernel %s has BTF already, skipping later kernels\n", pkg)
 				return nil
 			}
-			return err
+			if errors.Is(err, context.Canceled) {
+				return nil
+			}
+
+			log.Printf("ERROR: %s: %s\n", pkg, err)
+			continue
 		}
+
+		log.Printf("DEBUG: end pkg %s (%d/%d)\n", pkg, i+1, len(pkgs))
 	}
 
 	return nil

--- a/pkg/repo/centos.go
+++ b/pkg/repo/centos.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aquasecurity/btfhub/pkg/job"
 	"github.com/aquasecurity/btfhub/pkg/kernel"
 	"github.com/aquasecurity/btfhub/pkg/pkg"
+	"github.com/aquasecurity/btfhub/pkg/preflight"
 	"github.com/aquasecurity/btfhub/pkg/utils"
 )
 
@@ -83,6 +84,8 @@ func (d *CentosRepo) GetKernelPackages(
 
 	sort.Sort(pkg.ByVersion(pkgs)) // so kernels can be skipped if previous has BTF already
 
+	pkgs = filterPackagesByManifest(ctx, "centos", release, arch, pkgs)
+
 	for i, pkg := range pkgs {
 		log.Printf("DEBUG: start pkg %s (%d/%d)\n", pkg, i+1, len(pkgs))
 
@@ -93,6 +96,9 @@ func (d *CentosRepo) GetKernelPackages(
 
 		err := processPackage(ctx, pkg, workDir, force, jobChan)
 		if err != nil {
+			if errors.Is(err, preflight.ErrWorkFound) {
+				return err
+			}
 			if errors.Is(err, utils.ErrHasBTF) {
 				log.Printf("INFO: kernel %s has BTF already, skipping later kernels\n", pkg)
 				return nil

--- a/pkg/repo/debian.go
+++ b/pkg/repo/debian.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/aquasecurity/btfhub/pkg/job"
 	"github.com/aquasecurity/btfhub/pkg/pkg"
+	"github.com/aquasecurity/btfhub/pkg/preflight"
 	"github.com/aquasecurity/btfhub/pkg/utils"
 )
 
@@ -115,6 +116,8 @@ func (d *DebianRepo) GetKernelPackages(
 
 	sort.Sort(pkg.ByVersion(pkgs)) // so kernels can be skipped if previous has BTF already
 
+	pkgs = filterPackagesByManifest(ctx, "debian", release, arch, pkgs)
+
 	for i, pkg := range pkgs {
 		log.Printf("DEBUG: start pkg %s (%d/%d)\n", pkg, i+1, len(pkgs))
 
@@ -125,6 +128,9 @@ func (d *DebianRepo) GetKernelPackages(
 
 		err := processPackage(ctx, pkg, workDir, force, jobChan)
 		if err != nil {
+			if errors.Is(err, preflight.ErrWorkFound) {
+				return err
+			}
 			if errors.Is(err, utils.ErrHasBTF) {
 				log.Printf("INFO: kernel %s has BTF already, skipping later kernels\n", pkg)
 				return nil

--- a/pkg/repo/fedora.go
+++ b/pkg/repo/fedora.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aquasecurity/btfhub/pkg/job"
 	"github.com/aquasecurity/btfhub/pkg/kernel"
 	"github.com/aquasecurity/btfhub/pkg/pkg"
+	"github.com/aquasecurity/btfhub/pkg/preflight"
 	"github.com/aquasecurity/btfhub/pkg/utils"
 )
 
@@ -123,6 +124,8 @@ func (d *FedoraRepo) GetKernelPackages(
 
 	sort.Sort(pkg.ByVersion(pkgs)) // so kernels can be skipped if previous has BTF already
 
+	pkgs = filterPackagesByManifest(ctx, "fedora", release, arch, pkgs)
+
 	for i, pkg := range pkgs {
 		log.Printf("DEBUG: start pkg %s (%d/%d)\n", pkg, i+1, len(pkgs))
 
@@ -133,6 +136,9 @@ func (d *FedoraRepo) GetKernelPackages(
 
 		err := processPackage(ctx, pkg, workDir, force, jobChan)
 		if err != nil {
+			if errors.Is(err, preflight.ErrWorkFound) {
+				return err
+			}
 			if errors.Is(err, utils.ErrHasBTF) {
 				log.Printf("INFO: kernel %s has BTF already, skipping later kernels\n", pkg)
 				return nil

--- a/pkg/repo/oracle.go
+++ b/pkg/repo/oracle.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aquasecurity/btfhub/pkg/job"
 	"github.com/aquasecurity/btfhub/pkg/kernel"
 	"github.com/aquasecurity/btfhub/pkg/pkg"
+	"github.com/aquasecurity/btfhub/pkg/preflight"
 	"github.com/aquasecurity/btfhub/pkg/utils"
 )
 
@@ -81,6 +82,8 @@ func (d *oracleRepo) GetKernelPackages(
 
 	sort.Sort(pkg.ByVersion(pkgs)) // so kernels can be skipped if previous has BTF already
 
+	pkgs = filterPackagesByManifest(ctx, "ol", release, arch, pkgs)
+
 	for i, pkg := range pkgs {
 		log.Printf("DEBUG: start pkg %s (%d/%d)\n", pkg, i+1, len(pkgs))
 
@@ -91,6 +94,9 @@ func (d *oracleRepo) GetKernelPackages(
 
 		err := processPackage(ctx, pkg, workDir, force, jobChan)
 		if err != nil {
+			if errors.Is(err, preflight.ErrWorkFound) {
+				return err
+			}
 			if errors.Is(err, utils.ErrHasBTF) {
 				log.Printf("INFO: kernel %s has BTF already, skipping later kernels\n", pkg)
 				return nil

--- a/pkg/repo/rhel.go
+++ b/pkg/repo/rhel.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aquasecurity/btfhub/pkg/job"
 	"github.com/aquasecurity/btfhub/pkg/kernel"
 	"github.com/aquasecurity/btfhub/pkg/pkg"
+	"github.com/aquasecurity/btfhub/pkg/preflight"
 	"github.com/aquasecurity/btfhub/pkg/utils"
 )
 
@@ -63,6 +64,9 @@ func (d *RHELRepo) GetKernelPackages(
 	for _, pkg := range pkgs {
 		err := processPackage(ctx, pkg, workDir, force, jobChan)
 		if err != nil {
+			if errors.Is(err, preflight.ErrWorkFound) {
+				return err
+			}
 			if errors.Is(err, utils.ErrHasBTF) {
 				log.Printf("INFO: kernel %s has BTF already, skipping later kernels\n", pkg)
 				return nil

--- a/pkg/repo/suse.go
+++ b/pkg/repo/suse.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aquasecurity/btfhub/pkg/job"
 	"github.com/aquasecurity/btfhub/pkg/kernel"
 	"github.com/aquasecurity/btfhub/pkg/pkg"
+	"github.com/aquasecurity/btfhub/pkg/preflight"
 	"github.com/aquasecurity/btfhub/pkg/utils"
 )
 
@@ -139,6 +140,9 @@ func (d *suseRepo) processPackages(ctx context.Context, dir string, pkgs []pkg.P
 	for i, p := range pkgs {
 		log.Printf("DEBUG: start pkg %s (%d/%d)\n", p, i+1, len(pkgs))
 		if err := processPackage(ctx, p, dir, force, jobchan); err != nil {
+			if errors.Is(err, preflight.ErrWorkFound) {
+				return err
+			}
 			if errors.Is(err, utils.ErrHasBTF) {
 				log.Printf("INFO: kernel %s has BTF already, skipping later kernels\n", p)
 				return nil

--- a/pkg/repo/ubuntu.go
+++ b/pkg/repo/ubuntu.go
@@ -10,7 +10,9 @@ import (
 	"sort"
 
 	"github.com/aquasecurity/btfhub/pkg/job"
+	"github.com/aquasecurity/btfhub/pkg/manifest"
 	"github.com/aquasecurity/btfhub/pkg/pkg"
+	"github.com/aquasecurity/btfhub/pkg/preflight"
 	"github.com/aquasecurity/btfhub/pkg/utils"
 	"golang.org/x/sync/errgroup"
 )
@@ -71,6 +73,7 @@ func (uRepo *UbuntuRepo) GetKernelPackages(
 	if err != nil {
 		return fmt.Errorf("parsing main package list: %s", err)
 	}
+	rawPkgs = nil // drop large index buffer before fetching ddebs index (RSS)
 
 	// Filter out kernel packages that we already have or failed to download
 
@@ -105,6 +108,7 @@ func (uRepo *UbuntuRepo) GetKernelPackages(
 	if err != nil {
 		return fmt.Errorf("parsing debug package list: %s", err)
 	}
+	dbgRawPkgs = nil // drop large ddebs index buffer before building work maps (RSS)
 
 	// Filter out kernel packages that we already have or failed to download
 
@@ -152,6 +156,16 @@ func (uRepo *UbuntuRepo) GetKernelPackages(
 				URL:           "pull-lp-ddebs",
 			}
 		}
+	}
+
+	// Apply -manifest filter to the Ubuntu debug package map (same JSONL as other distros).
+	if f := manifest.FilterFromContext(ctx); f != nil {
+		for id := range filteredKernelDbgPkgMap {
+			if !f.Match("ubuntu", release, arch, id) {
+				delete(filteredKernelDbgPkgMap, id)
+			}
+		}
+		log.Printf("DEBUG: after manifest filter, %d %s packages\n", len(filteredKernelDbgPkgMap), arch)
 	}
 
 	log.Printf("DEBUG: %d %s packages\n", len(filteredKernelDbgPkgMap), arch)
@@ -214,6 +228,9 @@ func (d *UbuntuRepo) processPackages(
 		// 2. Extract BTF info from vmlinux file
 
 		if err := processPackage(ctx, pkg, workDir, force, jobChan); err != nil {
+			if errors.Is(err, preflight.ErrWorkFound) {
+				return err
+			}
 			if errors.Is(err, utils.ErrHasBTF) {
 				log.Printf("INFO: kernel %s has BTF already, skipping later kernels\n", pkg)
 				return nil

--- a/pkg/repo/utils.go
+++ b/pkg/repo/utils.go
@@ -16,7 +16,9 @@ import (
 
 	"github.com/aquasecurity/btfhub/pkg/job"
 	"github.com/aquasecurity/btfhub/pkg/kernel"
+	"github.com/aquasecurity/btfhub/pkg/manifest"
 	"github.com/aquasecurity/btfhub/pkg/pkg"
+	"github.com/aquasecurity/btfhub/pkg/preflight"
 	"github.com/aquasecurity/btfhub/pkg/utils"
 )
 
@@ -73,6 +75,24 @@ func yumSearch(ctx context.Context, pkg string) (*bytes.Buffer, error) {
 	return stdout, nil
 }
 
+// filterPackagesByManifest keeps only packages whose Filename() appears in the
+// manifest filter (from -manifest). No-op when no filter is set.
+func filterPackagesByManifest(ctx context.Context, distro, release, arch string, pkgs []pkg.Package) []pkg.Package {
+	f := manifest.FilterFromContext(ctx)
+	if f == nil {
+		return pkgs
+	}
+	var filtered []pkg.Package
+	for _, p := range pkgs {
+		if f.Match(distro, release, arch, p.Filename()) {
+			filtered = append(filtered, p)
+		}
+	}
+	log.Printf("DEBUG: after manifest filter, %d packages (distro=%s release=%s arch=%s)\n",
+		len(filtered), distro, release, arch)
+	return filtered
+}
+
 // processPackage creates a kernel extraction job and waits for the reply. It
 // then creates a BTF generation job and sends it to the worker. It returns
 func processPackage(
@@ -94,6 +114,20 @@ func processPackage(
 	if !force && utils.Exists(btfTarPath) {
 		log.Printf("SKIP: %s exists\n", btfTarName)
 		return nil
+	}
+
+	if preflight.FromContext(ctx) {
+		if mw := manifest.WriterFromContext(ctx); mw != nil {
+			t, ok := manifest.TemplateFromContext(ctx)
+			if !ok {
+				return fmt.Errorf("manifest-out set but template missing (internal error)")
+			}
+			if err := mw.Append(t, p.Filename()); err != nil {
+				return fmt.Errorf("manifest append: %w", err)
+			}
+			return nil
+		}
+		return preflight.ErrWorkFound
 	}
 
 	// 1st job: Extract kernel vmlinux file

--- a/pkg/utils/download.go
+++ b/pkg/utils/download.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bufio"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strings"
 
 	fastxz "github.com/therootcompany/xz"
 )
@@ -21,15 +23,46 @@ func DownloadFile(ctx context.Context, url string, file string) error {
 	}
 	defer f.Close()
 
-	return Download(ctx, url, f)
+	// Large binaries (ddebs, RPMs): never use BTFHUB_HTTP_CACHE here - it would
+	// duplicate the full payload on disk (.body + destination file). Metadata
+	// uses Download() into buffers and GetLinks(); those still use the cache.
+	return downloadNoCache(ctx, url, f)
+}
+
+// compressedLayer returns a reader that decompresses r when Content-Type indicates gzip/xz.
+func compressedLayer(r io.Reader, contentType string) (io.Reader, error) {
+	switch contentType {
+	case "application/x-gzip":
+		return gzip.NewReader(r)
+	case "application/x-xz":
+		return fastxz.NewReader(r, 0)
+	default:
+		return r, nil
+	}
+}
+
+// bodyReader applies HTTP Content-Encoding (e.g. gzip) then Content-Type-based compression.
+func bodyReader(r io.Reader, contentEncoding, contentType string) (io.Reader, error) {
+	if strings.Contains(strings.ToLower(contentEncoding), "gzip") {
+		gr, err := gzip.NewReader(r)
+		if err != nil {
+			return nil, fmt.Errorf("gzip content-encoding: %w", err)
+		}
+		r = gr
+	}
+	return compressedLayer(r, contentType)
 }
 
 // Download downloads a file from a given URL, and writes it to a given
 // destination, which can be a file or a pipe
 func Download(ctx context.Context, url string, dest io.Writer) error {
+	if httpCacheDir() != "" {
+		return downloadHTTPCached(ctx, url, dest)
+	}
+	return downloadNoCache(ctx, url, dest)
+}
 
-	// Request given URL
-
+func downloadNoCache(ctx context.Context, url string, dest io.Writer) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err
@@ -40,47 +73,36 @@ func Download(ctx context.Context, url string, dest io.Writer) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("%s returned status code: %d", url, resp.StatusCode)
 	}
 
-	// Create a progress counter reader
-
 	counter := &ProgressCounter{
 		Ctx:  ctx,
-		Op:   "Download",                 // operation
-		Name: resp.Request.URL.String(),  // file name
-		Size: uint64(resp.ContentLength), // file length
+		Op:   "Download",
+		Name: resp.Request.URL.String(),
+		Size: uint64(resp.ContentLength),
 	}
-	brdr := io.TeeReader(resp.Body, counter) // forward body reader to counter
+	brdr := io.TeeReader(resp.Body, counter)
 
-	// Deal with response (gzip, xz, plain): reader from the counter reader (act the body reader)
-
-	var rdr io.Reader
-
-	switch resp.Header.Get("Content-Type") {
-	case "application/x-gzip":
-		rdr, err = gzip.NewReader(brdr)
-		if err != nil {
-			return fmt.Errorf("gzip body read: %s", err)
-		}
-	case "application/x-xz":
-		rdr, err = fastxz.NewReader(brdr, 0)
-		if err != nil {
-			return fmt.Errorf("xz reader: %s", err)
-		}
-	default:
-		rdr = brdr
+	rdr, err := bodyReader(brdr, resp.Header.Get("Content-Encoding"), resp.Header.Get("Content-Type"))
+	if err != nil {
+		return err
 	}
 
-	_, err = io.Copy(dest, rdr) // copy to destination
-
+	_, err = io.Copy(dest, rdr)
 	return err
 }
 
 // GetLinks returns a list of links from a given URL
 func GetLinks(ctx context.Context, repoURL string) ([]string, error) {
-	// Read the repo URL
+	if httpCacheDir() != "" {
+		return getLinksHTTPCached(ctx, repoURL)
+	}
+	return getLinksNoCache(ctx, repoURL)
+}
+
+func getLinksNoCache(ctx context.Context, repoURL string) ([]string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, repoURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("http request: %s", err)
@@ -91,24 +113,51 @@ func GetLinks(ctx context.Context, repoURL string) ([]string, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("url %s returned %d", repoURL, resp.StatusCode)
 	}
 
+	return scanHTMLLinks(ctx, resp.Request.URL.String(), resp.Body, uint64(resp.ContentLength))
+}
+
+func getLinksHTTPCached(ctx context.Context, repoURL string) ([]string, error) {
+	raw, meta, err := fetchRawHTTPCached(ctx, repoURL)
+	if err != nil {
+		return nil, err
+	}
+	var ce, ct string
+	displayURL := repoURL
+	if meta != nil {
+		ce = meta.ContentEncoding
+		ct = meta.ContentType
+		if meta.FinalURL != "" {
+			displayURL = meta.FinalURL
+		}
+	}
+	rdr, err := bodyReader(bytes.NewReader(raw), ce, ct)
+	if err != nil {
+		return nil, err
+	}
+	decompressed, err := io.ReadAll(rdr)
+	if err != nil {
+		return nil, err
+	}
+	return scanHTMLLinks(ctx, displayURL, bytes.NewReader(decompressed), uint64(len(decompressed)))
+}
+
+func scanHTMLLinks(ctx context.Context, displayURL string, body io.Reader, size uint64) ([]string, error) {
 	re := regexp.MustCompile(`.*href="([^"]+)"`)
-
-	var links []string
-
-	// Create a progress counter reader
 
 	counter := &ProgressCounter{
 		Ctx:  ctx,
 		Op:   "Download",
-		Name: resp.Request.URL.String(),
-		Size: uint64(resp.ContentLength),
+		Name: displayURL,
+		Size: size,
 	}
 
-	scan := bufio.NewScanner(io.TeeReader(resp.Body, counter))
+	scan := bufio.NewScanner(io.TeeReader(body, counter))
+
+	var links []string
 
 	for scan.Scan() {
 		line := string(scan.Bytes())
@@ -118,10 +167,8 @@ func GetLinks(ctx context.Context, repoURL string) ([]string, error) {
 			continue
 		}
 
-		// Find all links in the line
-
 		for _, m := range matches {
-			res, err := url.JoinPath(repoURL, m[1])
+			res, err := url.JoinPath(displayURL, m[1])
 			if err != nil {
 				continue
 			}

--- a/pkg/utils/http_cache.go
+++ b/pkg/utils/http_cache.go
@@ -1,0 +1,275 @@
+package utils
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// BTFHUB_HTTP_CACHE, when set to a directory path, enables a simple on-disk cache
+// for utils.Download (streaming to non-file writers) and utils.GetLinks: responses
+// are keyed by URL (SHA-256), and conditional requests (If-None-Match /
+// If-Modified-Since) avoid re-downloading unchanged metadata (APT Packages indices,
+// repo directory listings, etc.). utils.DownloadFile does not use this cache so
+// large package downloads are not duplicated on disk.
+const httpCacheEnvVar = "BTFHUB_HTTP_CACHE"
+
+// Client without automatic gzip/deflate so ETag/Last-Modified match the on-disk body we persist.
+var httpCacheClient = &http.Client{
+	Transport: &http.Transport{
+		DisableCompression: true,
+	},
+}
+
+func httpCacheDir() string {
+	return strings.TrimSpace(os.Getenv(httpCacheEnvVar))
+}
+
+func httpCacheKey(url string) string {
+	sum := sha256.Sum256([]byte(url))
+	return hex.EncodeToString(sum[:])
+}
+
+// One mutex per cache key so concurrent workers do not clobber the same .body.part / rename.
+var httpCacheKeyLocks sync.Map // string (hex key) -> *sync.Mutex
+
+func lockHTTPCacheKey(key string) func() {
+	v, _ := httpCacheKeyLocks.LoadOrStore(key, new(sync.Mutex))
+	mu := v.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
+
+type httpCacheMeta struct {
+	ETag            string `json:"etag,omitempty"`
+	LastModified    string `json:"last_modified,omitempty"`
+	ContentType     string `json:"content_type,omitempty"`
+	ContentEncoding string `json:"content_encoding,omitempty"`
+	// FinalURL is the request URL after redirects (used by GetLinks for relative hrefs).
+	FinalURL string `json:"final_url,omitempty"`
+}
+
+func readHTTPMeta(path string) (*httpCacheMeta, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var m httpCacheMeta
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+func writeHTTPMeta(path string, m *httpCacheMeta) error {
+	if m == nil {
+		return errors.New("nil meta")
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func applyConditionalHeaders(req *http.Request, meta *httpCacheMeta) {
+	if meta == nil {
+		return
+	}
+	if meta.ETag != "" {
+		req.Header.Set("If-None-Match", meta.ETag)
+	}
+	if meta.LastModified != "" {
+		req.Header.Set("If-Modified-Since", meta.LastModified)
+	}
+}
+
+func metaFromResponse(resp *http.Response) *httpCacheMeta {
+	return &httpCacheMeta{
+		ETag:            resp.Header.Get("ETag"),
+		LastModified:    resp.Header.Get("Last-Modified"),
+		ContentType:     resp.Header.Get("Content-Type"),
+		ContentEncoding: resp.Header.Get("Content-Encoding"),
+		FinalURL:        resp.Request.URL.String(),
+	}
+}
+
+// downloadHTTPCached streams url into dest, persisting raw bytes under httpCacheDir when possible.
+func downloadHTTPCached(ctx context.Context, urlStr string, dest io.Writer) error {
+	dir := httpCacheDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("http cache mkdir: %w", err)
+	}
+	key := httpCacheKey(urlStr)
+	unlock := lockHTTPCacheKey(key)
+	defer unlock()
+
+	bodyPath := filepath.Join(dir, key+".body")
+	metaPath := filepath.Join(dir, key+".meta")
+
+	meta, _ := readHTTPMeta(metaPath)
+	if meta != nil {
+		if _, err := os.Stat(bodyPath); err != nil {
+			meta = nil // incomplete cache entry
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return err
+	}
+	applyConditionalHeaders(req, meta)
+
+	resp, err := httpCacheClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotModified && meta != nil {
+		f, err := os.Open(bodyPath)
+		if err != nil {
+			return fmt.Errorf("http cache 304 but missing body %s: %w", bodyPath, err)
+		}
+		defer f.Close()
+		st, _ := f.Stat()
+		var sz uint64
+		if st != nil {
+			sz = uint64(st.Size())
+		}
+		counter := &ProgressCounter{
+			Ctx:  ctx,
+			Op:   "Download",
+			Name: urlStr,
+			Size: sz,
+		}
+		brdr := io.TeeReader(f, counter)
+		rdr, err := bodyReader(brdr, meta.ContentEncoding, meta.ContentType)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(dest, rdr)
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s returned status code: %d", urlStr, resp.StatusCode)
+	}
+
+	newMeta := metaFromResponse(resp)
+	counter := &ProgressCounter{
+		Ctx:  ctx,
+		Op:   "Download",
+		Name: resp.Request.URL.String(),
+		Size: uint64(resp.ContentLength),
+	}
+
+	tmpBody := bodyPath + ".part"
+	out, err := os.Create(tmpBody)
+	if err != nil {
+		return fmt.Errorf("http cache create part: %w", err)
+	}
+	success := false
+	defer func() {
+		out.Close()
+		if !success {
+			_ = os.Remove(tmpBody)
+		}
+	}()
+
+	mw := io.MultiWriter(counter, out)
+	brdr := io.TeeReader(resp.Body, mw)
+	rdr, err := bodyReader(brdr, newMeta.ContentEncoding, newMeta.ContentType)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(dest, rdr); err != nil {
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpBody, bodyPath); err != nil {
+		return fmt.Errorf("http cache finalize body: %w", err)
+	}
+	if err := writeHTTPMeta(metaPath, newMeta); err != nil {
+		return fmt.Errorf("http cache write meta: %w", err)
+	}
+	success = true
+	return nil
+}
+
+// fetchRawHTTPCached returns the full response body bytes (as sent on the wire, still compressed if any).
+func fetchRawHTTPCached(ctx context.Context, urlStr string) ([]byte, *httpCacheMeta, error) {
+	dir := httpCacheDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, nil, fmt.Errorf("http cache mkdir: %w", err)
+	}
+	key := httpCacheKey(urlStr)
+	unlock := lockHTTPCacheKey(key)
+	defer unlock()
+
+	bodyPath := filepath.Join(dir, key+".body")
+	metaPath := filepath.Join(dir, key+".meta")
+
+	meta, _ := readHTTPMeta(metaPath)
+	if meta != nil {
+		if _, err := os.Stat(bodyPath); err != nil {
+			meta = nil
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	applyConditionalHeaders(req, meta)
+
+	resp, err := httpCacheClient.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotModified && meta != nil {
+		b, err := os.ReadFile(bodyPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("http cache 304 read body: %w", err)
+		}
+		return b, meta, nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil, fmt.Errorf("url %s returned %d", urlStr, resp.StatusCode)
+	}
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+	newMeta := metaFromResponse(resp)
+	tmpBody := bodyPath + ".part"
+	if err := os.WriteFile(tmpBody, raw, 0o644); err != nil {
+		return nil, nil, err
+	}
+	if err := os.Rename(tmpBody, bodyPath); err != nil {
+		return nil, nil, err
+	}
+	if err := writeHTTPMeta(metaPath, newMeta); err != nil {
+		return nil, nil, err
+	}
+	return raw, newMeta, nil
+}

--- a/tests/install-deps.sh
+++ b/tests/install-deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-set -x # for debugging
+# set -x # for debugging
 
 # This script installs the dependencies for compiling btfhub and running the
 # tests.
@@ -25,7 +25,7 @@ wait_for_apt_locks() {
 
     echo "Checking for unattended-upgrades..."
     while pgrep -f unattended-upgrades > /dev/null; do
-        if (( elapsed >= timeout )); then
+        if ((elapsed >= timeout)); then
             echo "Timed out waiting for unattended-upgrades to finish. Attempting to kill..."
             pkill -SIGQUIT -f unattended-upgrades || true
             pkill -SIGKILL -f unattended-upgrades || true
@@ -40,29 +40,29 @@ wait_for_apt_locks() {
     timeout=5 # reduce timeout for apt locks
     elapsed=0 # reset timer
 
-    while : ; do
-        if ! fuser $lock >/dev/null 2>&1 &&
-           ! fuser $lock_frontend >/dev/null 2>&1 &&
-           ! fuser $lock_lists >/dev/null 2>&1 &&
-           ! fuser $lock_archives >/dev/null 2>&1; then
+    while :; do
+        if ! fuser $lock > /dev/null 2>&1 \
+            && ! fuser $lock_frontend > /dev/null 2>&1 \
+            && ! fuser $lock_lists > /dev/null 2>&1 \
+            && ! fuser $lock_archives > /dev/null 2>&1; then
             echo "All apt locks are free."
             break
         fi
 
-        if (( elapsed >= timeout )); then
+        if ((elapsed >= timeout)); then
             echo "Timed out waiting for apt locks to be released. Attempting to kill locking processes."
-            fuser -k -SIGQUIT $lock >/dev/null 2>&1 || true
-            fuser -k -SIGQUIT $lock_frontend >/dev/null 2>&1 || true
-            fuser -k -SIGQUIT $lock_lists >/dev/null 2>&1 || true
-            fuser -k -SIGQUIT $lock_archives >/dev/null 2>&1 || true
+            fuser -k -SIGQUIT $lock > /dev/null 2>&1 || true
+            fuser -k -SIGQUIT $lock_frontend > /dev/null 2>&1 || true
+            fuser -k -SIGQUIT $lock_lists > /dev/null 2>&1 || true
+            fuser -k -SIGQUIT $lock_archives > /dev/null 2>&1 || true
 
             # Give some time for processes to terminate gracefully
             sleep 2
 
-            fuser -k -SIGKILL $lock >/dev/null 2>&1 || true
-            fuser -k -SIGKILL $lock_frontend >/dev/null 2>&1 || true
-            fuser -k -SIGKILL $lock_lists >/dev/null 2>&1 || true
-            fuser -k -SIGKILL $lock_archives >/dev/null 2>&1 || true
+            fuser -k -SIGKILL $lock > /dev/null 2>&1 || true
+            fuser -k -SIGKILL $lock_frontend > /dev/null 2>&1 || true
+            fuser -k -SIGKILL $lock_lists > /dev/null 2>&1 || true
+            fuser -k -SIGKILL $lock_archives > /dev/null 2>&1 || true
 
             # Delete lock files if they still exist
             rm -f $lock $lock_frontend $lock_lists $lock_archives
@@ -334,7 +334,7 @@ apt-get install -y \
 
 # Install dependencies based on the origin
 
-GO_VERSION="1.24.2"
+GO_VERSION="1.26.1"
 LLVM_VERSION="14.0.6"
 
 install_golang_from_github "$GO_VERSION"

--- a/tools/archive-sparse-checkout.sh
+++ b/tools/archive-sparse-checkout.sh
@@ -77,19 +77,19 @@ APPLY_ONLY=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --incremental|-i)
+        --incremental | -i)
             INCREMENTAL=true
             shift
             ;;
-        --exclude|-e)
+        --exclude | -e)
             EXCLUDE_MODE=true
             shift
             ;;
-        --no-apply|-n)
+        --no-apply | -n)
             NO_APPLY=true
             shift
             ;;
-        --apply-only|-a)
+        --apply-only | -a)
             APPLY_ONLY=true
             shift
             ;;
@@ -113,8 +113,7 @@ ARCHS="${ARCHS//aarch64/arm64}"
 
 for arch in $ARCHS; do
     case $arch in
-        x86_64|arm64|'*')
-            ;;
+        x86_64 | arm64 | '*') ;;
         *)
             die "invalid ARCH: $arch"
             ;;
@@ -195,7 +194,7 @@ if [ "$APPLY_ONLY" = false ]; then
             pattern="!$pattern"
         fi
         echo "$pattern" | tee $TEE_FLAG "$SPARSE_CHECKOUT_FILE"
-        TEE_FLAG="-a"  # After first iteration, always append
+        TEE_FLAG="-a" # After first iteration, always append
     }
 
     # Generate patterns based on DISTRO, ARCH, and VERSION
@@ -236,6 +235,6 @@ else
     echo "Applying sparse checkout and downloading files..."
     git -C "$ARCHIVE_DIR" sparse-checkout reapply || die "failed to reapply sparse-checkout"
     # Reset and checkout to force download of matching files
-    git -C "$ARCHIVE_DIR" reset --hard HEAD 2>/dev/null || echo "Reset completed"
+    git -C "$ARCHIVE_DIR" reset --hard HEAD 2> /dev/null || echo "Reset completed"
     echo "Sparse checkout completed successfully in $ARCHIVE_DIR"
 fi


### PR DESCRIPTION
…hains

- Split cron into list → generate → push (Amazon + distros); GitHub API path list (fetch-archive-paths-github.py); placeholders, collect/merge scripts; push gated on new blobs; job summaries and http-cache-summary
- Add commit-push-archive composite; ci-helpers (set_output, validate_ref); build-dependencies tweaks
- btfhub: -preflight/-index, -manifest-out/-manifest; pkg/manifest, pkg/preflight; processPackage manifest writer + filterPackagesByManifest across repos
- pkg/utils: conditional HTTP cache for metadata; DownloadFile without cache body dup
- Docker: Dockerfile.amazon/distros (digest-pinned bases, POSIX RUN), run-*.sh, docker/README; Makefile docker-* targets; dependabot /docker
- docs: README + docker/README cross-links; btfhub-archive-path-layout; small doc fixes
- go.mod 1.26.1; pr.yml, install-deps, pahole.sh, archive-sparse-checkout; ignore files