### PR TITLE
ci: improvements

### DIFF
--- a/.github/actions/build-dependencies/action.yaml
+++ b/.github/actions/build-dependencies/action.yaml
@@ -1,22 +1,27 @@
 name: Build Dependencies
+
 description: |
   Install build dependencies to test and compile btfhub artifacts
+
 inputs:
   from:
-    description: 'Install dependencies script option (pr, cron)'
+    description: "Install dependencies script option (pr, cron)"
     required: true
-    default: 'pr'
+    default: "pr"
   run-on:
-    description: 'Set working-directory to run'
+    description: "Set working-directory to run"
     required: false
-    default: '.'
+    default: "."
+
 runs:
   using: composite
   steps:
     #
     - name: Install ubuntu packages
+      env:
+        FROM: ${{ inputs.from }}
       run: |
-        ./tests/install-deps.sh ${{ inputs.from }}
+        ./tests/install-deps.sh "${FROM}"
       shell: bash
       working-directory: ${{ inputs.run-on }}
     #

--- a/.github/actions/commit-push-and-pr/action.yaml
+++ b/.github/actions/commit-push-and-pr/action.yaml
@@ -1,0 +1,71 @@
+name: Commit, Push and Create PR
+
+description: Commit changes, push to a timestamped branch, and create a PR. Distro names are auto-detected from changed file paths.
+
+inputs:
+  directory:
+    description: Path to the archive checkout
+    required: true
+  repository:
+    description: Target repository (owner/name)
+    required: true
+  branch-prefix:
+    description: Branch name prefix (e.g. ci/amazon)
+    required: true
+  token:
+    description: GitHub PAT for push and PR creation
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Commit, Push and Create PR
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        DIRECTORY: ${{ inputs.directory }}
+        REPOSITORY: ${{ inputs.repository }}
+        BRANCH_PREFIX: ${{ inputs.branch-prefix }}
+      run: |
+          cd "${DIRECTORY}"
+          git add -A
+          if git diff --cached --quiet; then
+              echo "No changes to commit"
+              exit 0
+          fi
+
+          # Detect distros from changed file paths (top-level directories)
+          DISTROS=$(git diff --cached --name-only | cut -d'/' -f1 | sort -u | paste -sd ', ')
+          echo "Detected distros: ${DISTROS}"
+
+          git diff --cached --stat
+
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
+
+          BRANCH="${BRANCH_PREFIX}-$(date +%Y%m%d%H%M%S)"
+          git checkout -b "${BRANCH}"
+          git commit -m "Update BTF archive: ${DISTROS}"
+          git remote set-url origin "https://x-access-token@github.com/${REPOSITORY}.git"
+
+          # Push using GIT_ASKPASS to provide the token via a short-lived script on disk (owner r-x only).
+          # The token is never exposed in command-line args for a long period.
+          GIT_ASKPASS_SCRIPT="$(mktemp)"
+          trap 'rm -f "${GIT_ASKPASS_SCRIPT}"' EXIT # ensure cleanup on any circumstances
+          exec {fd}>"${GIT_ASKPASS_SCRIPT}"
+          chmod 500 "${GIT_ASKPASS_SCRIPT}"
+          echo "this should fail" > "${GIT_ASKPASS_SCRIPT}" 2>&1 || echo "direct write blocked"
+          printf '#!/bin/sh\necho "${GH_TOKEN}"' >&${fd}
+          exec {fd}>&-
+
+          GIT_ASKPASS="${GIT_ASKPASS_SCRIPT}" \
+              git push -u origin "${BRANCH}"
+          rm -f "${GIT_ASKPASS_SCRIPT}" # remove it right away
+
+          # gh reads the token from the GH_TOKEN env var (no args, no disk)
+          gh pr create \
+              --repo "${REPOSITORY}" \
+              --base main \
+              --head "${BRANCH}" \
+              --title "Update BTF archive: ${DISTROS}" \
+              --body "Automated update of BTF files for: ${DISTROS}."
+      shell: bash

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,32 +1,55 @@
 name: Update BTFHub Archive
-permissions:
-  contents: read
+
+permissions: {}
+
+env:
+  ARCHIVE_REPO: aquasecurity/btfhub-archive
+
 on:
   schedule:
     - cron: "0 1 * * *"
+
   workflow_dispatch: {}
+
 jobs:
   amazon-update:
     name: Update Amazon 2 BTF Archive
     runs-on: ubuntu-2404-4core
     container:
       image: amazonlinux:2023
+    permissions:
+      contents: read # actions/setup-go cache save/restore
     steps:
       - name: Install needed amazon packages
         run: |
-          yum install -y yum-utils tar gzip xz clang make cmake git libdwarf-devel elfutils-libelf-devel elfutils-devel rsync
+          dnf install -y dnf-utils tar gzip xz clang make cmake git libdwarf-devel elfutils-libelf-devel elfutils-devel rsync
         shell: bash
       #
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
-        with:
-          go-version: "1.25"
+      - name: Install GitHub CLI
+        run: |
+          dnf install -y 'dnf-command(config-manager)'
+          dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+          dnf install -y gh
+        shell: bash
       #
       - name: Configure Git for HTTPS
         run: |
           # Force Git to use HTTPS instead of SSH to avoid terminal auth prompts
           git config --global url."https://github.com/".insteadOf "git@github.com:"
         shell: bash
+      #
+      - name: Checkout BTFHub
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: aquasecurity/btfhub
+          submodules: recursive
+          path: ./btfhub
+      #
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.25"
+          cache-dependency-path: btfhub/go.sum
       #
       - name: Configure Go Proxy
         run: |
@@ -38,14 +61,14 @@ jobs:
       - name: Setup Amazon Debuginfo Repositories
         run: |
           # disable default debuginfo repositories
-          yum-config-manager -y --disable amazonlinux-debuginfo
+          dnf config-manager --set-disabled amazonlinux-debuginfo
 
           # add Amazon Linux 2 debuginfo repositories
           append_repo() {
-            local arch=$1
-            local repo_name="amzn2-core-debuginfo-$arch"
-            
-            echo "[$repo_name]
+              local arch=$1
+              local repo_name="amzn2-core-debuginfo-$arch"
+
+              echo "[$repo_name]
           name=Amazon Linux 2 core repository - debuginfo packages $arch
           mirrorlist=http://amazonlinux.default.amazonaws.com/2/core/latest/debuginfo/$arch/mirror.list
           enabled=1
@@ -57,13 +80,6 @@ jobs:
           $(append_repo "aarch64")
           EOF
         shell: bash
-      #
-      - name: Checkout BTFHub
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: aquasecurity/btfhub
-          submodules: recursive
-          path: ./btfhub
       #
       - name: Build and install pahole
         run: |
@@ -94,8 +110,7 @@ jobs:
       - name: Checkout BTFHub Archive
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: aquasecurity/btfhub-archive
-          token: ${{ secrets.GEYSLAN_BTFHUB_PAT }}
+          repository: ${{ env.ARCHIVE_REPO }}
           persist-credentials: false
           fetch-depth: 1
           path: ./btfhub-archive
@@ -118,24 +133,18 @@ jobs:
           cd btfhub
           make take
       #
-      - name: Check Status
-        run: |
-          cd btfhub-archive
-          git status
-      #
-      - name: Commit and Push to BTFHub Archive
-        uses: actions-js/push@5a7cbd780d82c0c937b5977586e641b2fd94acc5 # v1.5
+      - name: Commit, Push and Create PR for BTFHub Archive
+        uses: ./btfhub/.github/actions/commit-push-and-pr
         with:
           directory: ./btfhub-archive
-          author_email: 'geyslan@gmail.com'
-          author_name: 'Geyslan Gregório'
-          github_token: ${{ secrets.GEYSLAN_BTFHUB_PAT }}
-          message: 'Update BTFHUB Archive from BTFHUB'
-          repository: aquasecurity/btfhub-archive
-          branch: main
+          repository: ${{ env.ARCHIVE_REPO }}
+          branch-prefix: ci/amazon
+          token: ${{ secrets.AQUASECURITY_BTFHUB_ARCHIVE_TOKEN }}
 
-  build:
-    name: Update BTF Archive
+  other-distros:
+    name: Update Other Distros BTF Archive
+    permissions:
+      contents: read # actions/cache save/restore
     env:
       HOME: "/tmp/root"
       GOPATH: "/tmp/go"
@@ -167,11 +176,25 @@ jobs:
           run-on: ./btfhub
           from: cron
       #
+      - name: Cache Go modules
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            ${{ env.GOPATH }}/pkg/mod
+            ${{ env.GOCACHE }}
+          key: ${{ runner.os }}-${{ runner.arch }}-go-graas-${{ hashFiles('**/go.mod') }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-go-graas-${{ hashFiles('**/go.mod') }}-
+      #
+      - name: Install GitHub CLI
+        run: |
+          apt-get update
+          apt-get install -y gh
+        shell: bash
+      #
       - name: Checkout BTFHub Archive
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: aquasecurity/btfhub-archive
-          token: ${{ secrets.GEYSLAN_BTFHUB_PAT }}
+          repository: ${{ env.ARCHIVE_REPO }}
           persist-credentials: false
           fetch-depth: 1
           path: ./btfhub-archive
@@ -225,18 +248,10 @@ jobs:
           cd btfhub
           make take
       #
-      - name: Check Status
-        run: |
-          cd btfhub-archive
-          git status
-      #
-      - name: Commit and Push to BTFHub Archive
-        uses: actions-js/push@5a7cbd780d82c0c937b5977586e641b2fd94acc5 # v1.5
+      - name: Commit, Push and Create PR for BTFHub Archive
+        uses: ./btfhub/.github/actions/commit-push-and-pr
         with:
           directory: ./btfhub-archive
-          author_email: 'gg@condado.dev'
-          author_name: 'Geyslan Gregório'
-          github_token: ${{ secrets.GEYSLAN_BTFHUB_PAT }}
-          message: 'Update BTFHUB Archive from BTFHUB'
-          repository: aquasecurity/btfhub-archive
-          branch: main
+          repository: ${{ env.ARCHIVE_REPO }}
+          branch-prefix: ci/other-distros
+          token: ${{ secrets.AQUASECURITY_BTFHUB_ARCHIVE_TOKEN }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   amazon-update:
     name: Update Amazon 2 BTF Archive
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2404-4core
     container:
       image: amazonlinux:2023
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,31 +1,32 @@
 name: PR
+
+permissions: {}
+
 on:
   workflow_dispatch: {}
+
   pull_request:
     branches:
       - main
     paths:
-      - "!docs/**"
-      - "!archive/**"
-      - "!custom-archive/**"
-      - "!tools/bin/**"
-      - "!**.yaml"
-      - "!**.md"
-      - "!**.txt"
-      - "!**.conf"
-      # override previous rules:
-      - "**.c"
-      - "**.h"
       - "**.go"
       - "**.sh"
-      - ".github/workflows/pr.yaml"
+      - "go.mod"
+      - "go.sum"
+      - "Makefile"
+      - ".github/workflows/pr.yml"
+      - ".github/actions/**"
+
 concurrency:
   group: ${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
 jobs:
   verify-and-test:
     name: Verify and Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read # actions/checkout
     steps:
       #
       - name: Checkout Code
@@ -42,7 +43,7 @@ jobs:
       #
       - name: Install staticchecker
         run: |
-          GOROOT=/usr/local/go GOPATH=$HOME/go go install honnef.co/go/tools/cmd/staticcheck@5af2e5fc3b08ba46027eb48ebddeba34dc0bd02c # 2025.1
+          GOROOT=/usr/local/go GOPATH=$HOME/go go install honnef.co/go/tools/cmd/staticcheck@ff63afafc529279f454e02f1d060210bd4263951 # v0.7.0 (2026.1)
           sudo cp $HOME/go/bin/staticcheck /usr/bin/
         shell: bash
       #
@@ -55,23 +56,27 @@ jobs:
       - name: Lint
         run: |
           if test -z "$(gofmt -l .)"; then
-            echo "Congrats! There is nothing to fix."
+              echo "Congrats! There is nothing to fix."
           else
-            echo "The following lines should be fixed."
-            gofmt -s -d .
-            exit 1
+              echo "The following lines should be fixed."
+              gofmt -s -d .
+              exit 1
           fi
+        shell: bash
       #
       - name: Check Golang Vet
         run: |
           make check-vet
+        shell: bash
       #
       - name: Check with StaticCheck
         run: |
           make check-staticcheck
+        shell: bash
       #
       # CODE TESTING
       #
       - name: Run Unit Tests
         run: |
           make test-unit
+        shell: bash


### PR DESCRIPTION
commit 33176359d36c56f7263302200d84f51502139da3

    ci: harden PR workflow and build-dependencies action
    
    - Set permissions to none at workflow level, contents:read per job
    - Pin runner to ubuntu-24.04 instead of ubuntu-latest
    - Fix shell injection in build-dependencies by routing input through env
    - Add explicit shell: bash to all run steps
    - Fix pr.yml self-trigger path (was .yaml, file is .yml)
    - Replace stale exclusion-based path filters with inclusion-based list
      that covers go, sh, go.mod, go.sum, Makefile, and actions

commit 72a1e4455bddaba304d47eb3a401d458a238a1e3

    ci: push archive updates via PR instead of direct push to main
    
    The btfhub-archive repository now enforces branch protection rules
    requiring changes through pull requests. Replace direct push to main
    (actions-js/push) with a composite action that creates a timestamped
    ci/ branch, pushes via GIT_ASKPASS (avoiding token exposure in args
    and git config), and opens a PR against main using gh CLI.
    
    Other changes:
    - Extract commit-and-push logic into a reusable composite action
    - Auto-detect affected distros from changed paths for commit/PR messages
    - Add ARCHIVE_REPO workflow-level env var to centralize repo reference
    - Harden inputs against shell injection by routing through env vars
    - Switch amazon-update job from yum to dnf (AL2023 primary pkg manager)
    - Install gh CLI in both runners (dnf for AL2023, apt for Ubuntu)
    - Add Go module cache for other-distros job (actions/cache on GRAAS)
    - Move btfhub checkout before setup-go to enable cache-dependency-path
    - Drop PAT from archive checkout (public repo, persist-credentials: false)
    - Set workflow permissions to none, grant minimal per-job permissions

commit 1a1e6d6147da74bb988d8e1234197341ee308b0b

    ci: use allowed runner