### PR TITLE
ci: use githubapp & skip duplicate PRs

### DIFF
--- a/.github/actions/commit-push-and-pr/action.yaml
+++ b/.github/actions/commit-push-and-pr/action.yaml
@@ -121,6 +121,46 @@ runs:
 
           git diff --cached --stat
 
+          # Deduplication: skip or supersede an existing open PR for this branch prefix.
+          # (Skipped in dry-run because the mock file would produce a false mismatch.)
+          if [[ "${DRY_RUN}" != "true" ]]; then
+              STAGED_FILES=$(git diff --cached --name-only | sort)
+
+              EXISTING_PR_NUMBER=$(gh pr list \
+                  --repo "${REPOSITORY}" \
+                  --base main \
+                  --state open \
+                  --json number,headRefName \
+                  --jq "[.[] | select(.headRefName | startswith(\"${BRANCH_PREFIX}-\"))] | first | .number // empty")
+
+              if [[ -n "${EXISTING_PR_NUMBER}" ]]; then
+                  echo "Found existing open PR #${EXISTING_PR_NUMBER} with prefix ${BRANCH_PREFIX}"
+
+                  EXISTING_FILES=$(gh pr view "${EXISTING_PR_NUMBER}" \
+                      --repo "${REPOSITORY}" \
+                      --json files \
+                      --jq '.files[].path' | sort)
+
+                  # Lines present in STAGED_FILES but absent from EXISTING_FILES
+                  NEW_FILES=$(comm -23 <(echo "${STAGED_FILES}") <(echo "${EXISTING_FILES}"))
+
+                  if [[ -z "${NEW_FILES}" ]]; then
+                      echo "Staged files are already covered by PR #${EXISTING_PR_NUMBER}. Commenting and skipping."
+                      gh pr comment "${EXISTING_PR_NUMBER}" \
+                          --repo "${REPOSITORY}" \
+                          --body "Cron run on $(date -u '+%Y-%m-%d') produced the same set of BTF files already tracked by this PR. No new PR created."
+                      exit 0
+                  fi
+
+                  NEW_FILES_LIST=$(echo "${NEW_FILES}" | paste -sd ', ')
+                  echo "Additional files vs PR #${EXISTING_PR_NUMBER}: ${NEW_FILES_LIST}. Closing old PR."
+                  gh pr comment "${EXISTING_PR_NUMBER}" \
+                      --repo "${REPOSITORY}" \
+                      --body "Closing in favour of a new PR that includes additional BTF files not present here: \`${NEW_FILES_LIST}\`."
+                  gh pr close "${EXISTING_PR_NUMBER}" --repo "${REPOSITORY}"
+              fi
+          fi
+
           mapfile -t _bot < <(gh api "/users/${APP_SLUG}[bot]" --jq '[.type, .login, (.id|tostring)] | .[]')
           if [[ ${#_bot[@]} -ne 3 ]]; then
               echo "Failed to resolve GitHub App bot user for ${APP_SLUG}[bot]" >&2

--- a/.github/actions/commit-push-and-pr/action.yaml
+++ b/.github/actions/commit-push-and-pr/action.yaml
@@ -103,6 +103,52 @@ runs:
       run: |
           cd "${DIRECTORY}"
 
+          write_job_summary() {
+              [[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0
+
+              {
+                  echo "## BTFHub Archive Update"
+                  echo ""
+                  case "${SUMMARY_RESULT}" in
+                      no_changes)
+                          echo "**Result:** No changes to commit"
+                          ;;
+                      skipped_duplicate)
+                          echo "**Result:** Skipped — existing PR already covers these files"
+                          ;;
+                      dry_run_ok)
+                          echo "**Result:** Dry run passed"
+                          ;;
+                      pr_created)
+                          echo "**Result:** Pull request created"
+                          ;;
+                  esac
+                  echo ""
+                  echo "| Field | Value |"
+                  echo "| --- | --- |"
+                  echo "| Repository | \`${REPOSITORY}\` |"
+                  [[ -n "${BRANCH_PREFIX:-}" ]] && echo "| Branch prefix | \`${BRANCH_PREFIX}\` |"
+                  [[ -n "${DISTROS:-}" ]] && echo "| Distros | ${DISTROS} |"
+                  [[ -n "${FILE_COUNT:-}" ]] && echo "| Files changed | ${FILE_COUNT} |"
+                  [[ -n "${BOT_LOGIN:-}" ]] && echo "| Author | \`${BOT_LOGIN}\` |"
+                  if [[ -n "${COMMIT_SHA:-}" ]]; then
+                      echo "| Commit | [\`${COMMIT_SHA:0:7}\`](https://github.com/${REPOSITORY}/commit/${COMMIT_SHA}) |"
+                  fi
+                  if [[ -n "${BRANCH:-}" ]]; then
+                      if [[ "${BRANCH_DELETED:-}" == "true" ]]; then
+                          echo "| Branch | \`${BRANCH}\` (deleted) |"
+                      else
+                          echo "| Branch | [\`${BRANCH}\`](https://github.com/${REPOSITORY}/tree/${BRANCH}) |"
+                      fi
+                  fi
+                  [[ -n "${ATTRIBUTED_LOGIN:-}" ]] && echo "| Attributed as | \`${ATTRIBUTED_LOGIN}\` |"
+                  [[ -n "${EXISTING_PR:-}" ]] && echo "| Existing PR | ${EXISTING_PR} |"
+                  [[ -n "${SUPERSEDED_PR:-}" ]] && echo "| Superseded PR | ${SUPERSEDED_PR} |"
+                  [[ -n "${PR_URL:-}" ]] && echo "| Pull request | ${PR_URL} |"
+                  [[ "${DRY_RUN}" == "true" ]] && echo "| Dry run | yes |"
+              } >> "${GITHUB_STEP_SUMMARY}"
+          }
+
           if [[ "${DRY_RUN}" == "true" ]]; then
               echo "=== DRY RUN: creating mock change ==="
               mkdir -p _test
@@ -111,18 +157,21 @@ runs:
 
           git add --sparse -A
           if git diff --cached --quiet; then
-              echo "No changes to commit"
+              SUMMARY_RESULT=no_changes
+              write_job_summary
               exit 0
           fi
 
           # Detect distros from changed file paths (top-level directories)
           DISTROS=$(git diff --cached --name-only | cut -d'/' -f1 | sort -u | paste -sd ', ')
+          FILE_COUNT=$(git diff --cached --name-only | wc -l | tr -d ' ')
           echo "Detected distros: ${DISTROS}"
 
           git diff --cached --stat
 
           # Deduplication: skip or supersede an existing open PR for this branch prefix.
           # (Skipped in dry-run because the mock file would produce a false mismatch.)
+          SUPERSEDED_PR=""
           if [[ "${DRY_RUN}" != "true" ]]; then
               STAGED_FILES=$(git diff --cached --name-only | sort)
 
@@ -145,15 +194,22 @@ runs:
                   NEW_FILES=$(comm -23 <(echo "${STAGED_FILES}") <(echo "${EXISTING_FILES}"))
 
                   if [[ -z "${NEW_FILES}" ]]; then
-                      echo "Staged files are already covered by PR #${EXISTING_PR_NUMBER}. Commenting and skipping."
+                      EXISTING_PR=$(gh pr view "${EXISTING_PR_NUMBER}" \
+                          --repo "${REPOSITORY}" \
+                          --json url --jq .url)
                       gh pr comment "${EXISTING_PR_NUMBER}" \
                           --repo "${REPOSITORY}" \
                           --body "Cron run on $(date -u '+%Y-%m-%d') produced the same set of BTF files already tracked by this PR. No new PR created."
+                      SUMMARY_RESULT=skipped_duplicate
+                      write_job_summary
                       exit 0
                   fi
 
                   NEW_FILES_LIST=$(echo "${NEW_FILES}" | paste -sd ', ')
                   echo "Additional files vs PR #${EXISTING_PR_NUMBER}: ${NEW_FILES_LIST}. Closing old PR."
+                  SUPERSEDED_PR=$(gh pr view "${EXISTING_PR_NUMBER}" \
+                      --repo "${REPOSITORY}" \
+                      --json url --jq .url)
                   gh pr comment "${EXISTING_PR_NUMBER}" \
                       --repo "${REPOSITORY}" \
                       --body "Closing in favour of a new PR that includes additional BTF files not present here: \`${NEW_FILES_LIST}\`."
@@ -184,13 +240,6 @@ runs:
           if [[ "$(git config user.email)" != "${EXPECTED_EMAIL}" ]]; then
               echo "git user.email mismatch: $(git config user.email) != ${EXPECTED_EMAIL}" >&2
               exit 1
-          fi
-
-          if [[ "${DRY_RUN}" == "true" ]]; then
-              echo "=== DRY RUN: commit identity ==="
-              echo "BOT_LOGIN=$(git config user.name)"
-              echo "BOT_ID=${BOT_ID}"
-              echo "BOT_EMAIL=$(git config user.email)"
           fi
 
           BRANCH="${BRANCH_PREFIX}-$(date +%Y%m%d%H%M%S)"
@@ -229,28 +278,24 @@ runs:
           fi
 
           if [[ "${DRY_RUN}" == "true" ]]; then
-              echo "=== DRY RUN: commit attribution verified ==="
-              echo "COMMIT_SHA=${COMMIT_SHA}"
-              echo "ATTRIBUTED_LOGIN=${ATTRIBUTED_LOGIN:-<unlinked>}"
-              echo "AUTHOR_NAME=${AUTHOR_NAME}"
-              echo "AUTHOR_EMAIL=${AUTHOR_EMAIL}"
-          fi
-
-          if [[ "${DRY_RUN}" == "true" ]]; then
-              echo "=== DRY RUN: push succeeded, deleting test branch ==="
               git push origin --delete "${BRANCH}"
-              echo "=== DRY RUN: credential-cache test passed ==="
+              BRANCH_DELETED=true
               cleanup_creds
+              SUMMARY_RESULT=dry_run_ok
+              write_job_summary
               exit 0
           fi
 
           cleanup_creds
 
-          # gh reads the token from the GH_TOKEN env var (no args, no disk)
-          gh pr create \
+          PR_URL=$(gh pr create \
               --repo "${REPOSITORY}" \
               --base main \
               --head "${BRANCH}" \
               --title "Update BTF archive: ${DISTROS}" \
-              --body "Automated update of BTF files for: ${DISTROS}."
+              --body "Automated update of BTF files for: ${DISTROS}." \
+              --json url --jq .url)
+
+          SUMMARY_RESULT=pr_created
+          write_job_summary
       shell: bash

--- a/.github/actions/commit-push-and-pr/action.yaml
+++ b/.github/actions/commit-push-and-pr/action.yaml
@@ -4,16 +4,19 @@ description: Commit changes, push to a timestamped branch, and create a PR. Dist
 
 inputs:
   directory:
-    description: Path to the archive checkout
+    description: Path to the archive checkout (relative, inside workspace, git repo)
     required: true
   repository:
     description: Target repository (owner/name)
     required: true
   branch-prefix:
-    description: Branch name prefix (e.g. ci/amazon)
+    description: Branch name prefix (must match ci/<name>, name = lowercase letters, digits, hyphens)
     required: true
-  token:
-    description: GitHub PAT for push and PR creation
+  app-client-id:
+    description: GitHub App client ID for push and PR creation
+    required: true
+  app-private-key:
+    description: GitHub App private key for push and PR creation
     required: true
   dry-run:
     description: "Test credential flow: create a mock change, push, then delete the branch (no PR created)"
@@ -23,12 +26,78 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Commit, Push and Create PR
+    - name: Parse and validate inputs
+      id: inputs
+      shell: bash
+      run: |
+          owner="${REPOSITORY%%/*}"
+          if [[ -z "${owner}" || "${owner}" == "${REPOSITORY}" ]]; then
+              echo "repository must be owner/name" >&2
+              exit 1
+          fi
+
+          if [[ ! "${BRANCH_PREFIX}" =~ ^ci/[a-z0-9-]+$ ]]; then
+              echo "branch-prefix must match ci/<name> (name: lowercase ASCII letters, digits, hyphens)" >&2
+              exit 1
+          fi
+
+          if [[ "${DIRECTORY}" == /* ]]; then
+              echo "directory must be a relative path" >&2
+              exit 1
+          fi
+
+          if [[ "${DIRECTORY}" == *..* ]]; then
+              echo "directory must not contain .." >&2
+              exit 1
+          fi
+
+          if [[ ! "${DIRECTORY}" =~ ^(\./)?[a-zA-Z0-9._-]+(/[a-zA-Z0-9._-]+)*$ ]]; then
+              echo "directory must be a relative path of allowed ASCII segments (letters, digits, ., _, -)" >&2
+              exit 1
+          fi
+
+          resolved="$(realpath -e "${GITHUB_WORKSPACE}/${DIRECTORY#./}")"
+          case "${resolved}" in
+              "${GITHUB_WORKSPACE}"|"${GITHUB_WORKSPACE}"/*) ;;
+              *)
+                  echo "directory must stay inside the workspace" >&2
+                  exit 1
+                  ;;
+          esac
+
+          if [[ ! -d "${resolved}/.git" ]]; then
+              echo "directory must be an existing git checkout" >&2
+              exit 1
+          fi
+
+          {
+              echo "owner=${owner}"
+              echo "branch-prefix=${BRANCH_PREFIX}"
+              echo "directory=${resolved}"
+          } >> "${GITHUB_OUTPUT}"
       env:
-        GH_TOKEN: ${{ inputs.token }}
-        DIRECTORY: ${{ inputs.directory }}
         REPOSITORY: ${{ inputs.repository }}
         BRANCH_PREFIX: ${{ inputs.branch-prefix }}
+        DIRECTORY: ${{ inputs.directory }}
+
+    - name: Generate GitHub App token
+      id: app-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      with:
+        client-id: ${{ inputs.app-client-id }}
+        private-key: ${{ inputs.app-private-key }}
+        owner: ${{ steps.inputs.outputs.owner }}
+        repositories: ${{ inputs.repository }}
+        permission-contents: write
+        permission-pull-requests: write
+
+    - name: Commit, Push and Create PR
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        DIRECTORY: ${{ steps.inputs.outputs.directory }}
+        REPOSITORY: ${{ inputs.repository }}
+        BRANCH_PREFIX: ${{ steps.inputs.outputs.branch-prefix }}
         CRED_CACHE_TIMEOUT: "60"
         DRY_RUN: ${{ inputs.dry-run }}
       run: |
@@ -52,8 +121,37 @@ runs:
 
           git diff --cached --stat
 
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git config user.name 'github-actions[bot]'
+          mapfile -t _bot < <(gh api "/users/${APP_SLUG}[bot]" --jq '[.type, .login, (.id|tostring)] | .[]')
+          if [[ ${#_bot[@]} -ne 3 ]]; then
+              echo "Failed to resolve GitHub App bot user for ${APP_SLUG}[bot]" >&2
+              exit 1
+          fi
+          BOT_TYPE="${_bot[0]}"
+          BOT_LOGIN="${_bot[1]}"
+          BOT_ID="${_bot[2]}"
+          EXPECTED_EMAIL="${BOT_ID}+${BOT_LOGIN}@users.noreply.github.com"
+          git config user.name "${BOT_LOGIN}"
+          git config user.email "${EXPECTED_EMAIL}"
+
+          if [[ "${BOT_TYPE}" != "Bot" ]]; then
+              echo "GitHub App bot user type is ${BOT_TYPE}, expected Bot" >&2
+              exit 1
+          fi
+          if [[ "$(git config user.name)" != "${BOT_LOGIN}" ]]; then
+              echo "git user.name mismatch: $(git config user.name) != ${BOT_LOGIN}" >&2
+              exit 1
+          fi
+          if [[ "$(git config user.email)" != "${EXPECTED_EMAIL}" ]]; then
+              echo "git user.email mismatch: $(git config user.email) != ${EXPECTED_EMAIL}" >&2
+              exit 1
+          fi
+
+          if [[ "${DRY_RUN}" == "true" ]]; then
+              echo "=== DRY RUN: commit identity ==="
+              echo "BOT_LOGIN=$(git config user.name)"
+              echo "BOT_ID=${BOT_ID}"
+              echo "BOT_EMAIL=$(git config user.email)"
+          fi
 
           BRANCH="${BRANCH_PREFIX}-$(date +%Y%m%d%H%M%S)"
           git checkout -b "${BRANCH}"
@@ -71,6 +169,32 @@ runs:
               | git credential approve
 
           git push -u origin "${BRANCH}"
+
+          COMMIT_SHA=$(git rev-parse HEAD)
+          mapfile -t _commit < <(gh api "/repos/${REPOSITORY}/commits/${COMMIT_SHA}" \
+              --jq '[.author.login // "", .commit.author.name, .commit.author.email] | .[]')
+          ATTRIBUTED_LOGIN="${_commit[0]}"
+          AUTHOR_NAME="${_commit[1]}"
+          AUTHOR_EMAIL="${_commit[2]}"
+
+          if [[ "${AUTHOR_NAME}" != "${BOT_LOGIN}" || "${AUTHOR_EMAIL}" != "${EXPECTED_EMAIL}" ]]; then
+              echo "Commit attribution mismatch:" >&2
+              echo "  expected name=${BOT_LOGIN} email=${EXPECTED_EMAIL}" >&2
+              echo "  got name=${AUTHOR_NAME} email=${AUTHOR_EMAIL}" >&2
+              exit 1
+          fi
+          if [[ -n "${ATTRIBUTED_LOGIN}" && "${ATTRIBUTED_LOGIN}" != "${BOT_LOGIN}" ]]; then
+              echo "Linked author login mismatch: ${ATTRIBUTED_LOGIN} != ${BOT_LOGIN}" >&2
+              exit 1
+          fi
+
+          if [[ "${DRY_RUN}" == "true" ]]; then
+              echo "=== DRY RUN: commit attribution verified ==="
+              echo "COMMIT_SHA=${COMMIT_SHA}"
+              echo "ATTRIBUTED_LOGIN=${ATTRIBUTED_LOGIN:-<unlinked>}"
+              echo "AUTHOR_NAME=${AUTHOR_NAME}"
+              echo "AUTHOR_EMAIL=${AUTHOR_EMAIL}"
+          fi
 
           if [[ "${DRY_RUN}" == "true" ]]; then
               echo "=== DRY RUN: push succeeded, deleting test branch ==="

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -152,7 +152,8 @@ jobs:
           directory: ./btfhub-archive
           repository: ${{ env.ARCHIVE_REPO }}
           branch-prefix: ci/amazon
-          token: ${{ secrets.AQUASECURITY_BTFHUB_ARCHIVE_TOKEN }}
+          app-client-id: ${{ secrets.REPO_BTFHUB_ARCHIVE_WRITE_GH_APP_CLIENT_ID }}
+          app-private-key: ${{ secrets.REPO_BTFHUB_ARCHIVE_WRITE_GH_APP_PRIVATE_KEY }}
           dry-run: ${{ inputs.dry-run && 'true' || 'false' }}
 
   other-distros:
@@ -290,5 +291,6 @@ jobs:
           directory: ./btfhub-archive
           repository: ${{ env.ARCHIVE_REPO }}
           branch-prefix: ci/other-distros
-          token: ${{ secrets.AQUASECURITY_BTFHUB_ARCHIVE_TOKEN }}
+          app-client-id: ${{ secrets.REPO_BTFHUB_ARCHIVE_WRITE_GH_APP_CLIENT_ID }}
+          app-private-key: ${{ secrets.REPO_BTFHUB_ARCHIVE_WRITE_GH_APP_PRIVATE_KEY }}
           dry-run: ${{ inputs.dry-run && 'true' || 'false' }}


### PR DESCRIPTION
commit 4c7448002a5c7b32f42d4556a7c2ed63d2ac43d0

    ci: add job summary to archive commit action
    
    Write a markdown step summary for all outcomes (no changes, skipped
    duplicate, dry run, and PR created) with links to commits, branches, and PRs.

commit 5074deb2d44bf188fee3c671f8c893427c5505fa

    ci: skip duplicate archive PRs and supersede when files change
    
    Compare staged BTF files against the newest open PR for the same branch
    prefix; comment and skip when unchanged, or close the old PR when new files appear.

commit 9acece7312232278eb5bf3a3edd9a2360e804878

    ci: authenticate archive updates with GitHub App
    
    Replace the archive PAT with a GitHub App installation token so cron
    jobs can push branches and open PRs using the archive write app secrets.